### PR TITLE
add workflows for manipulating github contract repos

### DIFF
--- a/github_repo/Dockerfile
+++ b/github_repo/Dockerfile
@@ -1,0 +1,18 @@
+FROM alpine/git:v2.30.2
+#FROM alpine:3.14
+
+RUN apk add --no-cache curl coreutils bash
+#RUN apk add --no-cache libc6-compat
+
+ENV GITHUB_CLI_VERSION 2.0.0
+
+RUN set -ex; \
+    curl -L "https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_checksums.txt" -o checksums.txt; \
+    curl -OL "https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz"; \
+    sha256sum --ignore-missing -c checksums.txt; \
+    tar xf gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz; \
+    rm -rf "gh_${GITHUB_CLI_VERSION}_linux_amd64.tar.gz"; \
+    cp gh_${GITHUB_CLI_VERSION}_linux_amd64/bin/gh /bin
+
+ENTRYPOINT ["bin/gh"]
+

--- a/github_repo/create-cluster-site.yaml
+++ b/github_repo/create-cluster-site.yaml
@@ -1,0 +1,47 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-create-cluster-site
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: contract_id
+      value: "contract_uuid"
+    - name: cluster_id
+      value: "cluster_uuid"
+  templates:
+  - name: createClusterSite
+    activeDeadlineSeconds: 120
+    container:
+      name: 'createClusterSite'
+      image: ghcr.io/sktelecom/ghcli-alpine:2.0.0
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        git clone https://${USERNAME}:${TOKEN}@github.com/tks-management/${CONTRACT_ID}.git
+        cd ${CONTRACT_ID}
+        cp -r template-site ${CLUSTER_ID}
+
+        git config --global user.email "taco_support@sk.com"
+        git config --global user.name "SKTelecom TACO"
+
+        git add ${CLUSTER_ID}
+        git commit -m "add new ${CLUSTER_ID} site"
+        git push origin main
+      envFrom:
+        - secretRef:
+            name: "github-tks-mgmt-token"
+      env:
+      - name: CONTRACT_ID
+        value: "{{workflow.parameters.contract_id}}"
+      - name: CLUSTER_ID
+        value: "{{workflow.parameters.cluster_id}}"
+  - name: main
+    steps:
+      - - name: createClusterSite
+          template: createClusterSite
+          arguments: {}

--- a/github_repo/create-contract-repo.yaml
+++ b/github_repo/create-contract-repo.yaml
@@ -1,0 +1,82 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-create-contract-repo
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: contract_id
+      value: "contract_uuid"
+  templates:
+  - name: createContractRepo
+    activeDeadlineSeconds: 120
+    container:
+      name: 'createRepo'
+      image: ghcr.io/sktelecom/ghcli-alpine:2.0.0
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        echo $TOKEN | gh auth login --with-token
+        echo "===== Current tks-management repo list ====="
+        gh repo list tks-management
+
+        echo "===== Create and initialize tks-management/${CONTRACT_ID} site and manifests repositories ====="
+        gh repo create tks-management/${CONTRACT_ID} --private --confirm
+        gh repo create tks-management/${CONTRACT_ID}-manifests --private --confirm
+
+        cd ${CONTRACT_ID}
+        echo -n ${TOKEN} | gh secret set API_TOKEN_GITHUB
+
+        gh repo clone tks-management/decapod-site-tks-template-manifests
+        cd decapod-site-tks-template-manifests
+        git remote add new_contract https://${USERNAME}:${TOKEN}@github.com/tks-management/${CONTRACT_ID}-manifests
+        git push new_contract main:main
+        cd ..
+
+        gh repo clone tks-management/decapod-site-tks-template
+        cd decapod-site-tks-template
+        git remote add new_contract https://${USERNAME}:${TOKEN}@github.com/tks-management/${CONTRACT_ID}
+        git push new_contract main:main
+        cd ..
+      envFrom:
+        - secretRef:
+            name: "github-tks-mgmt-token"
+      env:
+        - name: CONTRACT_ID
+          value: "{{workflow.parameters.contract_id}}"
+  - name: createRepoCredential
+    activeDeadlineSeconds: 120
+    container:
+      name: 'createCredential'
+      image: docker.io/sktdev/argocd:latest
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        echo "===== Connect github repo tks-management/${CONTRACT_ID}-manifests with token ====="
+        # log into Argo CD server
+        ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
+        --password $ARGO_PASSWORD
+
+        ./argocd repo add https://github.com/tks-management/${CONTRACT_ID}-manifests --username ${USERNAME} --password ${TOKEN}
+      envFrom:
+        - secretRef:
+            name: "github-tks-mgmt-token"
+        - secretRef:
+            name: "decapod-argocd-config"
+      env:
+        - name: CONTRACT_ID
+          value: "{{workflow.parameters.contract_id}}"
+  - name: main
+    steps:
+      - - name: createContractRepository
+          template: createContractRepo
+          arguments: {}
+      - - name: createRepoCredential
+          template: createRepoCredential
+          arguments: {}

--- a/github_repo/create-github-token-secret.yaml
+++ b/github_repo/create-github-token-secret.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-create-github-token-secret
+  namespace: argo
+spec:
+  entrypoint: createTokenSecret
+  arguments:
+    parameters:
+    - name: user
+      value: "github_user"
+    - name: token
+      value: "github_token"
+  templates:
+  - name: createTokenSecret
+    activeDeadlineSeconds: 120
+    container:
+      name: 'createClusterSite'
+      image: 'k8s.gcr.io/hyperkube:v1.18.8'
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        kubectl delete secret -n argo github-tks-mgmt-token || true
+        kubectl create secret generic github-tks-mgmt-token --from-literal=USERNAME=${USER} --from-literal=TOKEN=${TOKEN} -n argo
+      env:
+      - name: USER
+        value: "{{workflow.parameters.user}}"
+      - name: TOKEN
+        value: "{{workflow.parameters.token}}"


### PR DESCRIPTION
총 3개의 workflow로 내용은 아래와 같습니다.

1. create-github-token-secret.yaml: github-tks-mgmt-token 라는 이름으로 아래 2개의 워크플로우에서 github 접근 시 사용할 token을 저장
2. create-contract-repo.yaml: contract 및 contract-manifests 저장소를 private 으로 생성, argocd에 private 저장소 접근을 위한 credential 설정
3. create-cluster-site.yaml: user cluster 생성 시 contract 저장소에 사이트 추가, 완료되면 2번 contract 저장소에서 github action을 통해 manifest가 자동으로 생성

github 저장소 생성 및 secret 등 설정을 위해 github cli를 사용하였고 Dockerfile도 포함되어 있습니다.
