### PR TITLE
TACODEV-909: create user cluster and other

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -1,0 +1,124 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: create-tks-usercluster
+  namespace: argo
+spec:
+  entrypoint: deploy
+  arguments:
+    parameters:
+    - name: contract_id
+      value: "011b88fa-4d53-439f-9336-67845f994051"
+    - name: cluster_id
+      value: "67845f99"
+    - name: git_account
+      value: "tks-management"
+    - name: revision
+      value: main
+    - name: tks_admin
+      value: "tks-admin"
+    - name: app_name
+      value: "tks-cluster"
+
+  templates:
+  - name: deploy
+    dag:
+      tasks:
+      - name: tks-create-cluster-site
+        template: new-cluster-site
+        dependencies: []
+
+      - name: k8s-by-capi
+        templateRef:
+          name: tks-create-application
+          template: AppGroupOnAdmin
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "cluster-api-aws", "namespace": "argo" }
+              ]
+        dependencies: [tks-create-cluster-site]
+
+      - name: wait-for-clster-is-registered
+        template: wait-template
+        dependencies: [k8s-by-capi]
+
+      - name: ready-for-cni-and-csi
+        templateRef:
+          name: tks-create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "ingress-nginx", "namespace": "taco-system" },
+                { "path": "kubed", "namespace": "taco-system" },
+                { "path": "kubernetes-addons", "namespace": "taco-system" }
+              ]
+        dependencies: [k8s-by-capi, wait-for-clster-is-registered ]
+
+  - name: wait-template
+    activeDeadlineSeconds: 1800
+    container:
+      image: ghcr.io/openinfradev/argocd-cli:v2.0.1
+      command:
+      - /bin/bash
+      - -exc
+      - |
+        yes | ./argocd login --insecure $ARGO_SERVER --username $ARGO_USERNAME --password $ARGO_PASSWORD
+
+        while [ $(./argocd cluster list | grep \ $target\ | wc -l ) == 0 ]; do
+            echo "> Wait for cluster is registered"
+            sleep 30
+        done
+      envFrom:
+      - secretRef:
+          name: "decapod-argocd-config"
+      env:
+      - name: target
+        value: "{{workflow.parameters.cluster_id}}"
+
+  - name: new-cluster-site
+    container:
+      # image: golang:1.10
+      image: ghcr.io/openinfradev/python_kubectl:v1.0.1
+      command:
+      - /bin/bash
+      - -exc
+      - |
+        git clone https://$(echo $gittoken|xargs)@github.com/$git_account/$contract_id.git
+        cd $contract_id
+        if [ -d $cluster_id ]; then
+          echo "Cluster($cluster_id) already exists."
+          exit 1
+        fi
+        cp -r template-site $cluster_id
+        sed -i "s/clusterName:\ cluster.local/clusterName:\ $cluster_id/g" $cluster_id/*/site-values.yaml
+        git config --global user.email "taco@tacocloud.com"
+        git config --global user.name "argo-workflow"
+        git add $cluster_id
+        git commit -m "new site: $cluster_id"
+        git push
+
+        # buffer for starting the github action
+        sleep 30
+
+        # waiting for complete of the github action
+        echo $gittoken| gh auth login --with-token
+        gh run watch $(gh run list --workflow GenerateYaml --limit 1| grep $cluster_id | awk -F push '{print $2}' | awk '{print $1}')
+
+      envFrom:
+        - secretRef:
+            name: "gittoken"
+      env:
+        - name: contract_id
+          value: "{{workflow.parameters.contract_id}}"
+        - name: cluster_id
+          value: "{{workflow.parameters.cluster_id}}"
+        - name: git_account
+          value: "{{workflow.parameters.git_account}}"
+        - name: revision
+          value: "{{workflow.parameters.revision}}"

--- a/tks-cluster/secret-github.yaml
+++ b/tks-cluster/secret-github.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gittoken
+  namespace: argo
+data:
+  gittoken: Z2hwX3haZWY2QmtHS0hWSDQ4ek0xczlFMGNrazltMTdETTFXQVlEbQo=

--- a/tks-cluster/tks-createapp-wftp.yaml
+++ b/tks-cluster/tks-createapp-wftp.yaml
@@ -1,0 +1,111 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-create-application
+  namespace: argo
+spec:
+  arguments:
+    parameters:
+    - name: cluster_id
+      value: "hanu-deploy-apps"
+    - name: app_name
+      value: "lma"
+    - name: repository_url
+      value: "https://github.com/openinfradev/decapod-manifests"
+    - name: revision
+      value: main
+  templates:
+  - name: createApp
+    inputs:
+      parameters:
+      - name: path
+      - name: namespace
+      - name: target_cluster
+    activeDeadlineSeconds: 900
+    container:
+      image: ghcr.io/openinfradev/argocd-cli:v2.0.1
+      command:
+      - /bin/bash
+      - -c
+      - |
+        #CD_APP=$PATH
+        #NAMESPACE=$SITE_NAME
+        CD_APP=${SITE_NAME:0:8}-$PATH
+        echo "argo-cd application name: $CD_APP"
+        # log into Argo CD server
+        ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
+        --password $ARGO_PASSWORD
+
+        # check if app already exists.
+        REPO=https://$(echo $gittoken|xargs)@github.com/$git_account/${contract_id}-manifests.git
+        ./argocd app get $CD_APP 
+        if [[ $? -ne 0 ]]; then
+          echo "$CD_APP application is not in server"
+          # create new application if not exists.
+          echo ./argocd app create $CD_APP --repo $REPO --revision $REVISION --path $SITE_NAME/$TACO_APP/$PATH --dest-namespace $NAMESPACE --dest-name $TARGET_CLUSTER --project $TACO_APP --label app=$TACO_APP --directory-recurse
+          ./argocd app create $CD_APP --repo $REPO --revision $REVISION \
+            --path $SITE_NAME/$TACO_APP/$PATH \
+            --dest-namespace $NAMESPACE --dest-name $TARGET_CLUSTER \
+            --project $TACO_APP --label app=$TACO_APP --directory-recurse
+
+          if [[ $? -ne 0 ]]; then
+            exit $?
+          fi
+        fi
+
+        ./argocd app set $CD_APP --sync-policy automated --auto-prune
+        ./argocd app sync $CD_APP --async
+        ./argocd app wait $CD_APP --health
+      envFrom:
+        - secretRef:
+            name: "decapod-argocd-config"
+        - secretRef:
+            name: "gittoken"
+      env:
+        - name: PATH
+          value: "{{inputs.parameters.path}}"
+        - name: SITE_NAME
+          value: "{{workflow.parameters.cluster_id}}"
+        - name: TARGET_CLUSTER
+          value: "{{inputs.parameters.target_cluster}}"
+        - name: TACO_APP
+          value: "{{workflow.parameters.app_name}}"
+        - name: NAMESPACE
+          value: "{{inputs.parameters.namespace}}"
+        - name: REVISION
+          value: "{{workflow.parameters.revision}}"
+        - name: contract_id
+          value: "{{workflow.parameters.contract_id}}"
+        - name: cluster_id
+          value: "{{workflow.parameters.cluster_id}}"
+        - name: git_account
+          value: "{{workflow.parameters.git_account}}"
+
+
+  - name: AppGroup
+    inputs:
+      parameters:
+      - name: list
+    steps:
+    - - name: "InstallAppGroup"
+        template: createApp
+        arguments:
+          parameters:
+          - {name: path, value: "{{item.path}}"}
+          - {name: namespace, value: "{{item.namespace}}"}
+          - {name: target_cluster, value: "{{workflow.parameters.cluster_id}}"}
+        withParam: "{{inputs.parameters.list}}"
+
+  - name: AppGroupOnAdmin
+    inputs:
+      parameters:
+      - name: list
+    steps:
+    - - name: "InstallAppGroup"
+        template: createApp
+        arguments:
+          parameters:
+          - {name: path, value: "{{item.path}}"}
+          - {name: namespace, value: "{{item.namespace}}"}
+          - {name: target_cluster, value: "{{workflow.parameters.tks_admin}}"}
+        withParam: "{{inputs.parameters.list}}"


### PR DESCRIPTION
https://github.com/openinfradev/helm-charts/pull/68 가 완료되어야 정식지원됩니다.
현재도 수동빌드를 통해 docker image와 helm chart를 넣어두어서 구성된 환경 (github, argo, github package...)에서는 잘 돌아가는 것 확인완료
본 PR에 있는 create-tks-usercluster 등의 템플릿도 이미 환경에 올라가 있습니다.
https://argo-v2.taco-cat.xyz/workflow-templates/argo/create-tks-usercluster

본 PR에서 올라가는 workflow는 다음 내역을 포함합니다.

- cluster 준비 및 초기값 설정 
- github action 시작을 통한 manifest 생성 및 완료추적
- aws에 cluster api를 통해 사용자 클러스터(k8s cluster) 배포 
- 생성된 사용자 클러스터 초기화:  label  설정, namespace 설정, argocd에 등록
- 생성된 사용자 클러스터에 기본 프로그램 설치: cni/csi 설치, kubed 설치, ingress-controller 설치