### PR TITLE
create-usercluster: use cluster.local domain for new cluster

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -96,7 +96,6 @@ spec:
           exit 1
         fi
         cp -r template-site $cluster_id
-        sed -i "s/clusterName:\ cluster.local/clusterName:\ $cluster_id/g" $cluster_id/*/site-values.yaml
         git config --global user.email "taco@tacocloud.com"
         git config --global user.name "argo-workflow"
         git add $cluster_id


### PR DESCRIPTION
Cluster API를 통해 생성된 사용자 클러스터의 기본 도메인은 cluster.local을 사용하기 때문에 cluster-id 로 변경하던 부분을 제거하였습니다.