### PR TITLE
Use hanu-reference template as standard user site template

### DIFF
--- a/github_repo/create-contract-repo.yaml
+++ b/github_repo/create-contract-repo.yaml
@@ -37,6 +37,12 @@ spec:
         cp -r decapod-site/hanu-reference tks-user-site-template/template-std
 
         cd tks-user-site-template
+        # Remove unnecessary app_group directory before commit.
+        # If these kinds of apps increases, then they might be defined as black list
+        # and then removed by FOR loop iteration.
+        # For now, this hardcoding seems enough.
+        rm -rf template-std/openstack template-std/decapod-controller
+
         git config --global user.email "taco_support@sk.com"
         git config --global user.name "SKTelecom TACO"
         git add .


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/76

tks-user-site-template 중 std 템플릿은 decapod-site의 hanu-reference 를 공유하기로 결정함에 따라, 최초 contract-repo 생성시 hanu-reference 를 가져오는 부분 추가함. 

사실 엄밀히는 tks-cluster 디렉토리 부분만 tks 쪽으로 빼놓고 합치는게 나머지는 decaopd 쪽에서 가져오는게 맞지만, 복잡도 증가를 우려하는 의견이 있으므로 우선은 이정도로만 구현합니다. 