### PR TITLE
Add wf template for deleting cluster git repo

### DIFF
--- a/github_repo/Dockerfile
+++ b/github_repo/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine/git:v2.30.2
 RUN apk add --no-cache curl coreutils bash
 #RUN apk add --no-cache libc6-compat
 
-ENV GITHUB_CLI_VERSION 2.0.0
+ENV GITHUB_CLI_VERSION 2.5.1
 
 RUN set -ex; \
     curl -L "https://github.com/cli/cli/releases/download/v${GITHUB_CLI_VERSION}/gh_${GITHUB_CLI_VERSION}_checksums.txt" -o checksums.txt; \

--- a/github_repo/delete-cluster-site.yaml
+++ b/github_repo/delete-cluster-site.yaml
@@ -1,0 +1,32 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-delete-cluster-site
+  namespace: argo
+spec:
+  entrypoint: deleteClusterSite
+  arguments:
+    parameters:
+    - name: cluster_id
+      value: "cluster_uuid"
+  templates:
+  - name: deleteClusterSite
+    activeDeadlineSeconds: 120
+    container:
+      name: 'deleteClusterSite'
+      image: sktcloud/ghcli:2.5.1
+      imagePullPolicy: Always
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        echo $TOKEN | gh auth login --with-token
+
+        gh repo delete tks-management/${CLUSTER_ID} --confirm
+        gh repo delete tks-management/${CLUSTER_ID}-manifests --confirm
+      envFrom:
+        - secretRef:
+            name: "github-tks-mgmt-token"
+      env:
+      - name: CLUSTER_ID
+        value: "{{workflow.parameters.cluster_id}}"


### PR DESCRIPTION
- delete tks-management/<cluster-id> repo
- delete tks-management/<cluster-id>-manifests repo
- git repo 삭제를 지원하는 gh 2.5.1 이미지 사용 (알파인 리눅스에 bash, gh 설치한 커스텀 이미지)

# 테스트 방법
## 준비사항: 삭제할 클러스터 git repo 생성
- https://argo-v2.taco-cat.xyz/workflows/argo 접속
- Submit New Workflow에서 `tks-create-cluster-site` 선택
- Contract ID, Cluster ID 입력 
- Contract ID: 94e89b43-7224-4162-b3e5-4b1dc38d8eb2 (다른 contract id도 가능)
- Cluster ID: 자유롭게 입력
- workflow 실행하여 아래 Repo 생성 확인
- https://github.com/tks-management/Cluster-id
- https://github.com/tks-management/Cluster-id-manifests
## 클러스터 git repo 삭제
- https://argo-v2.taco-cat.xyz/workflows/argo 접속
- Submit New Workflow에서 `tks-delete-cluster-site` 선택
- Cluster ID 입력
- workflow 실행하여 아래 Repo 삭제 확인
- https://github.com/tks-management/Cluster-id
- https://github.com/tks-management/Cluster-id-manifests