### PR TITLE
call remove-lma-fed WF to delete LMA group

### DIFF
--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -26,7 +26,7 @@ spec:
     - name: app_prefix
       value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"
     - name: filter
-      value: "app={{workflow.parameters.app_prefix}}-{{workflow.parameters.app_group}}"
+      value: "app={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}-{{workflow.parameters.app_group}}"
   volumes:
   - name: tks-proto-vol
     configMap:


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/97

코멘트 남긴대로, delete-apps를 직접 호출하는 대신 secrets 삭제 등의 작업이 추가된 remove-lma-fed wf를 호출하도록 수정함

remove-lma-fed 수정 PR: https://github.com/openinfradev/decapod-flow/pull/72

-----
추가로 아래 bug 해결을 위한 PR과도 sync 맞추었습니다.
https://github.com/openinfradev/decapod-flow/pull/73