### PR TITLE
delete SERVICE_MESH endpoint

### DIFF
--- a/deploy_apps/tks-service-mesh-wftpl.yaml
+++ b/deploy_apps/tks-service-mesh-wftpl.yaml
@@ -51,7 +51,7 @@ spec:
           parameters:
           # TODO: Can this be pre-determined? Or composed dynamically on deployment?
           - name: endpoints
-            value: "{'SERVICE-MESH': 'dashboard.cluster_xy'}"
+            value: "{}"
           - name: app_group_status
             value: "APP_GROUP_RUNNING"
 


### PR DESCRIPTION
service-mesh 는 app 의 endpoint 를 설정할 필요가 없기 때문에 empty dictionary 를 넣어주는 것으로 변경한다.