### PR TITLE
add internal communication for gathering metrics

### DIFF
--- a/tks-cluster/aws_kubectl.Dockerfile
+++ b/tks-cluster/aws_kubectl.Dockerfile
@@ -1,0 +1,7 @@
+# make a docker image with this CLI: sudo docker build -f ./aws_kubectl.Dockerfile .
+FROM amazon/aws-cli
+
+# RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+# if the line above was fail, download it in locally and use the line below
+COPY kubectl /usr/bin/kubectl
+RUN chmod +x /usr/bin/kubectl

--- a/tks-cluster/awsconfig/config
+++ b/tks-cluster/awsconfig/config
@@ -1,0 +1,3 @@
+[default]
+region = ap-northeast-2
+output = text

--- a/tks-cluster/awsconfig/credentials
+++ b/tks-cluster/awsconfig/credentials
@@ -1,0 +1,3 @@
+[default]
+aws_access_key_id = FIX_ME
+aws_secret_access_key = FIX_ME

--- a/tks-cluster/create-internal-communication.yaml
+++ b/tks-cluster/create-internal-communication.yaml
@@ -1,0 +1,103 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: create-internal-communication
+  namespace: argo
+spec:
+  entrypoint: deploy
+  arguments:
+    parameters:
+    - name: cluster_id
+      value: "c81dd656-b75f-4990-adfb-76b0fc9ef7db"
+
+  volumes:
+    - name: config
+      secret:
+        secretName: tks-admin-kubeconfig-secret
+    - name: awsconfig
+      secret:
+        secretName: awsconfig-secret
+    - name: artifacts
+      configMap:
+        name: aws-artifacts
+        defaultMode: 0555
+
+  templates:
+  - name: deploy
+    dag:
+      tasks:
+      - name: create-securitygroup-for-internal-communication
+        template: CreateInternalCon
+        dependencies: []
+      - name: modify-resource-for-monitoring
+        template: FixResources4Prometheus
+        dependencies: []
+        
+  - name: CreateInternalCon
+    activeDeadlineSeconds: 1800
+    container:
+      image: ghcr.io/openinfradev/aws_kubectl:v1.0.0
+      command:
+      - /bin/bash
+      - -exc
+      - |
+        mkdir ~/.aws
+        cp /aws/* ~/.aws/
+        mkdir ~/.kube
+        cp /kube/value ~/.kube/config
+
+        # Gether VPC info.   
+        VPC=$(kubectl get awscluster -n $cluster_id $cluster_id -o=jsonpath={.spec.network.vpc.id})
+        CIDR=$(kubectl get awscluster -n $cluster_id $cluster_id -o=jsonpath={.spec.network.vpc.cidrBlock})
+
+        # Create Security Group
+        SG=$(aws ec2 create-security-group --group-name taco-internal --description "Security group for interanl communication among nodes" --vpc-id $VPC)
+        # Set ingress rule
+        aws ec2 authorize-security-group-ingress --group-id $SG --protocol tcp --port 237 --cidr $CIDR
+
+        # Add Security Group to all node in the VPC
+        for instance in `aws ec2 describe-instances --filters "Name=vpc-id,Values=$VPC" --query "Reservations[].Instances[].InstanceId"`
+        do
+          current=$(aws ec2 describe-instance-attribute --attribute "groupSet" --instance-id $instance --query "Groups[].GroupId" --output text)
+          aws ec2 modify-instance-attribute --instance-id $instance --groups $current $SG
+        done
+
+      env:
+      - name: cluster_id
+        value: "{{workflow.parameters.cluster_id}}"
+      volumeMounts:
+      - name: config
+        mountPath: "/kube"
+      - name: awsconfig
+        mountPath: "/aws"
+
+  - name: FixResources4Prometheus
+    activeDeadlineSeconds: 1800
+    container:
+      image: ghcr.io/openinfradev/aws_kubectl:v1.0.0
+      command:
+      - /bin/bash
+      - -exc
+      - |
+        mkdir ~/.kube
+        cp /kube/value ~/.kube/config
+
+        kubectl get secret -n $cluster_id ${cluster_id}-kubeconfig -o=jsonpath='{.data.value}' | base64 -d > ~/.kube/config
+
+        sleep 1000
+        # FIX network of kubeproxy to use cluster network
+        kubectl patch daemonset -n kube-system kube-proxy -p '{"spec":{"template":{"spec":{"hostNetwork":false}}}}' 
+
+        # FIX binding address of kubeproxy's metric server to 0.0.0.0
+        kubectl get cm -n kube-system kube-proxy -o yaml > /tmp/kube-proxy.cm.yaml
+        sed -i 's/metricsBindAddress: ""/metricsBindAddress: 0.0.0.0:10249/g' /tmp/kube-proxy.cm.yaml
+        kubectl apply -f /tmp/kube-proxy.cm.yaml
+
+      env:
+      - name: cluster_id
+        value: "{{workflow.parameters.cluster_id}}"
+      volumeMounts:
+      - name: config
+        mountPath: "/kube"
+      - name: awsconfig
+        mountPath: "/aws"

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -104,6 +104,11 @@ spec:
                 }
               ]
 
+    - - name: create-internal-communication
+        templateRef:
+          name: create-internal-communication
+          template: deploy
+
     - - name: update-cluster-status-to-running
         templateRef:
           name: update-tks-cluster-status
@@ -116,7 +121,6 @@ spec:
   #######################
   # Template Definition #
   #######################
-
   - name: wait-for-cluster-registration
     activeDeadlineSeconds: 1800
     container:

--- a/tks-cluster/init.sh
+++ b/tks-cluster/init.sh
@@ -3,3 +3,5 @@ kubectl delete -n argo secret tks-admin-kubeconfig-secret
 
 kubectl create -n argo cm aws-artifacts --from-file=artifacts
 kubectl create -n argo secret generic tks-admin-kubeconfig-secret --from-file=value=${HOME}/.kube/config
+
+kubectl create -n argo secret generic awsconfig-secret --from-file=config=awsconfig/config --from-file=credentials=awsconfig/credentials


### PR DESCRIPTION
다음내역을 포함
- aws cli를 포함하는 도커이미지용 dockerfile
- aws security group 생성 및 모든 인스턴스에 부여
- 생성된 클러스터의 kubeproxy 네트워크 조작 (cluster network)
- 생성된 클러스터의 kubeproxy 설정 조작 (exporter binding address 변경)

이를 위해 신규 워크플로를 추가하고 cluster 생성 프로시져의 최종 등록 전 실행하도록 추가