### PR TITLE
tks-cluster: create-tks-usercluster: fix kubeconfig secret key name

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -174,22 +174,22 @@ spec:
         - /bin/bash
         - '-cx'
         - |
-          cp /kube/value kubeconfig-adm
+          cp /kube/value kubeconfig
 
           CLUSTER=tks-admin-v2
           ADMIN_USER=tks-admin-v2-admin
           TOKEN=$(kubectl get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
-          kubectl --kubeconfig kubeconfig-adm config set-credentials cluster-autoscaler --token=$TOKEN
-          kubectl --kubeconfig kubeconfig-adm config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
-          kubectl --kubeconfig kubeconfig-adm config use-context cluster-autoscaler
-          kubectl --kubeconfig kubeconfig-adm config delete-context "$ADMIN_USER@$CLUSTER"
-          kubectl --kubeconfig kubeconfig-adm config delete-user "$ADMIN_USER"
+          kubectl --kubeconfig kubeconfig config set-credentials cluster-autoscaler --token=$TOKEN
+          kubectl --kubeconfig kubeconfig config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
+          kubectl --kubeconfig kubeconfig config use-context cluster-autoscaler
+          kubectl --kubeconfig kubeconfig config delete-context "$ADMIN_USER@$CLUSTER"
+          kubectl --kubeconfig kubeconfig config delete-user "$ADMIN_USER"
 
           KUBECONFIG_WORKLOAD=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig_workload:\n$KUBECONFIG_WORKLOAD" | head -n 5
           cat <<< "$KUBECONFIG_WORKLOAD" > kubeconfig_workload
 
-          kubectl --kubeconfig kubeconfig_workload -n kube-system create secret generic mgmt-kubeconfig --from-file=kubeconfig-adm
+          kubectl --kubeconfig kubeconfig_workload -n kube-system create secret generic mgmt-kubeconfig --from-file=kubeconfig
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"


### PR DESCRIPTION
cluster-autoscaler 가 참조하는 admin 클러스터 접근용 kubeconfig secret의 키 이름을 Helm chart 내용(https://github.com/openinfradev/helm-charts/blob/8537f8a6636dbf62ff85abefab761fba9a76d162/cluster-autoscaler/templates/deployment.yaml#L49) 에 맞게 수정합니다. 