### PR TITLE
Tks cluster fix prepare cluster autoscaler

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -178,7 +178,7 @@ spec:
 
           CLUSTER=tks-admin-v2
           ADMIN_USER=tks-admin-v2-admin
-          TOKEN=$(kubectl get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
+          TOKEN=$(kubectl --kubeconfig kubeconfig get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl --kubeconfig kubeconfig get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
           kubectl --kubeconfig kubeconfig config set-credentials cluster-autoscaler --token=$TOKEN
           kubectl --kubeconfig kubeconfig config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
           kubectl --kubeconfig kubeconfig config use-context cluster-autoscaler


### PR DESCRIPTION
아래 2가지 사항을 수정하였습니다.

- kubectl config delete-user 명령어를 사용하기 위해 prepare-cluster-autoscaler 워크플로우의 이미지 변경
- cluster-autoscaler 서비스 어카운트 토큰을 얻기 위해 admin kubeconfig를 명시적으로 사용