### PR TITLE
only pass contract_id to GetClusters RPC call

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -230,7 +230,7 @@ spec:
             # TODO: export this as step output to use it on next step
             cur_cluster_name = res.cluster.id
 
-            res = cl_stub.GetClusters(info_pb2.GetClustersRequest(contract_id=contract_id, csp_id=csp_id))
+            res = cl_stub.GetClusters(info_pb2.GetClustersRequest(contract_id=contract_id, csp_id=''))
 
             print("Iterating over clusters in the same contract...")
 


### PR DESCRIPTION
규격이 둘 중의 한 param만 제공하게 되어있어 contract_id 만 전달