### PR TITLE
install snapshot crds before ebs-csi-driver

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -90,6 +90,9 @@ spec:
     - - name: prepare-cluster-autoscaler
         template: prepare-cluster-autoscaler
 
+    - - name: install-volumesnapshot-crds
+        template: install-volumesnapshot-crds
+
     - - name: install-addons
         templateRef:
           name: create-application
@@ -196,3 +199,19 @@ spec:
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"
+
+  - name: install-volumesnapshot-crds
+    container:
+      name: install-volumesnapshot-crds
+      image: 'portainer/kubectl-shell:latest-v1.21.1-amd64'
+      command:
+        - /bin/bash
+        - '-cx'
+        - |
+          KUBECONFIG=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          echo -e "kubeconfig:\n$KUBECONFIG" | head -n 5
+          cat <<< "$KUBECONFIG" > kubeconfig_temp
+
+          kubectl --kubeconfig kubeconfig_temp apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml -n kube-system
+          kubectl --kubeconfig kubeconfig_temp apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml -n kube-system
+          kubectl --kubeconfig kubeconfig_temp apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml -n kube-system


### PR DESCRIPTION
ebs-csi-driver 설치시 snapshotter sidecar 설치가 되려면 미리 관련 crd들이 배포되어 있어야 하므로, crd 설치하는 부분 추가합니다. 
우선은 이렇게 간단히 진행하고, 향후 배포 파이프라인을 확장하여 (kustomize 소스 기반) argocd app 형태로 설치하는 방안을 생각 중입니다. 