### PR TITLE
Fix get tks admin cluster name

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -184,7 +184,7 @@ spec:
       image: 'portainer/kubectl-shell:latest-v1.21.1-amd64'
       command:
         - /bin/bash
-        - '-cx'
+        - '-exc'
         - |
           cp /kube/value kubeconfig
 
@@ -212,7 +212,7 @@ spec:
       image: 'portainer/kubectl-shell:latest-v1.21.1-amd64'
       command:
         - /bin/bash
-        - '-cx'
+        - '-exc'
         - |
           KUBECONFIG=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig:\n$KUBECONFIG" | head -n 5


### PR DESCRIPTION
- Admin 클러스터 이름을 얻기위해 명시적으로 default 네임스페이스를 사용하도록 수정
- 워크플로우 내 쉘 명령어 실행 중 오류 발생 시 중단하도록 옵션 추가