### PR TITLE
bugfix. change privilege to public

### DIFF
--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -29,8 +29,8 @@ spec:
       - |
         echo $TOKEN | gh auth login --with-token
 
-        gh repo create ${USERNAME}/${CLUSTER_ID} --private --confirm
-        gh repo create ${USERNAME}/${CLUSTER_ID}-manifests --private --confirm
+        gh repo create ${USERNAME}/${CLUSTER_ID} --public --confirm
+        gh repo create ${USERNAME}/${CLUSTER_ID}-manifests --public --confirm
 
         git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CONTRACT_ID}.git
 

--- a/github_repo/create-contract-repo.yaml
+++ b/github_repo/create-contract-repo.yaml
@@ -28,7 +28,7 @@ spec:
         gh repo list ${USERNAME}
 
         echo "===== Create and initialize ${USERNAME}/${CONTRACT_ID} site and manifests repositories ====="
-        gh repo create ${USERNAME}/${CONTRACT_ID} --private --confirm
+        gh repo create ${USERNAME}/${CONTRACT_ID} --public --confirm
 
         cd ${CONTRACT_ID}
         echo -n ${TOKEN} | gh secret set API_TOKEN_GITHUB


### PR DESCRIPTION
contract, cluster 생성시 사용하는 git repository 의 privilege 를 private 에서 public 으로 변경합니다.
demo-decapod10 에서 cluster 생성이 실패하기 때문입니다. ( 유료 plan 에서만 org secret 사용 가능한 이슈와 연관 )