### PR TITLE
Add kubeconfig for linting workflow template

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ on:
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  lint:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -49,33 +49,36 @@ jobs:
           # Test installation
           argo version
 
-      # Make fake kubeconfig for executing argo cli
-      - name: Make fake kubeconfig
+      # Make kubeconfig for executing argo cli
+      - name: Make  kubeconfig
+        env:
+          CLUSTER_CA: ${{ secrets.TEST_CLUSTER_CA }}
+          CLUSTER_URL: ${{ secrets.TEST_CLUSTER_URL }}
         run: |
-          cat <<EOF > /tmp/fakekubeconfig
+          cat <<EOF > /tmp/kubeconfig
           apiVersion: v1
-          kind: Config
           clusters:
           - cluster:
-              certificate-authority-data: ZHVtbXkK
-              server: https://localhost:6443
-            name: dummy
+              certificate-authority-data: $CLUSTER_CA
+              server: $CLUSTER_URL
+            name: tks-cicd
           contexts:
           - context:
-              cluster: dummy
-              user: dummy
-            name: dummy
-          current-context: dummy
+              cluster: tks-cicd
+              user: argo
+            name: argo@tks-cicd
+          current-context: argo@tks-cicd
+          kind: Config
           preferences: {}
           users:
-          - name: dummy
+          - name: argo
             user:
-              username: dummy
-              password: dummy
+              username: test
+              password: test
           EOF
-          cat /tmp/fakekubeconfig
+          cat /tmp/kubeconfig
           
       # Runs a Lint command
       - name: Lint changed file
         run: |
-          argo template lint --kubeconfig /tmp/fakekubeconfig ${{ steps.changed-files.outputs.all_changed_files }}
+          argo template lint --kubeconfig /tmp/kubeconfig ${{ steps.changed-files.outputs.all_changed_files }}


### PR DESCRIPTION
(https://github.com/openinfradev/decapod-flow/pull/92 와 동일)

# HISTORY
1. `argo template lint` 명령으로 워크플로우템플릿 검증 시 local에 있는 워크플로우템플릿 파일에 경우에도 쿠버네티스 컨피그를 요구함(아래 3과 같은 이유로 추측)
2. 액션 인스턴스에서 접근할 수 있는 쿠버네티스 클러스터가 마땅치 않아 fake kubeconfig를 사용함
3. 워크플로우템플릿이 내부에서 다른 워크플로우템플릿을 호출하는 경우 이 워크플로우템플릿을 쿠버네티스 클러스터에서 찾는데 
4. 이 때마다 fake kubeconfig에 있는 서버로 접근하려 하고 connection refused에러 발생 (https://github.com/openinfradev/decapod-flow/runs/5766950526?check_suite_focus=true)

# FIX
- CI용 클러스터가 구축됨에 따라(https://github.com/openinfradev/tks-issues/issues/88 ) fake kubeconfig를 CI용 클러스터의 kubeconfig로 교체 
-  kubeconfig에 명시된 user `test`는 존재하지 않는 유저로 쿠버네티스에서 'system:anonymous'권한으로 실행됨
-  `argo template lint`에서 필요한 get workflowtemplate만 수행할 수 있도록 cicd 클러스터에 롤바인딩 적용하여 다른 보안 위협 제거 