### PR TITLE
create-cluster-repo: extend deadline to prevent unnecessary failure

### DIFF
--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -15,7 +15,7 @@ spec:
       value: "template-std"
   templates:
   - name: createClusterRepo
-    activeDeadlineSeconds: 120
+    activeDeadlineSeconds: 300
     inputs:
       parameters:
       - name: cluster_info


### PR DESCRIPTION
클러스터 GIt 저장소 (site and manifests) 생성 과정에서 렌더링이 자동으로 수행됩니다. 현재 설정된 2분 시간으로는 부족한 경우가 많아 불필요하게 워크플루우가 중단되는 경우가 발생하여 데드라인을 5분으로 증가합니다.