### PR TITLE
create-tks-usercluster: change cluster autoscaler rbac installation order

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -72,7 +72,21 @@ spec:
                   "path": "cluster-api-aws",
                   "namespace": "argo",
                   "target_cluster": "tks-admin"
-                },
+                }
+              ]
+
+    - - name: wait-for-clster-to-be-registered
+        template: wait-for-cluster-registration
+
+    - - name: install-cluster-autoscaler-rbac
+        templateRef:
+          name: create-application
+          template: installApps
+        arguments:
+          parameters:
+          - name: list
+            value: |
+              [
                 {
                   "app_group": "tks-cluster-aws",
                   "path": "cluster-autoscaler-rbac",
@@ -80,9 +94,6 @@ spec:
                   "target_cluster": "tks-admin"
                 }
               ]
-
-    - - name: wait-for-clster-to-be-registered
-        template: wait-for-cluster-registration
 
     - - name: prepare-cluster-autoscaler
         template: prepare-cluster-autoscaler
@@ -95,7 +106,7 @@ spec:
           name: create-application
           template: installApps
         arguments:
-          parameters: 
+          parameters:
           - name: list
             value: |
               [


### PR DESCRIPTION
clustar-api-aws와 cluster-autoscaler-rbac 를 연속해서 설치하는 기존 방법의 경우 타이밍에 따라 클러스터 네임스페이스가 생성되지 않은 시점에 cluster-autoscaler-rbac가 설치되려고 해서 오류가 발생하는 경우가 있습니다.
이를 방지하기 위해 클러스터 생성 완료 이후에 cluster-autoscaler-rbac 설치를 수행하도록 순서를 변경하였습니다.