### PR TITLE
Add app-serving workflow

### DIFF
--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -114,10 +114,8 @@ spec:
         # Deploy
         kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}}
 
-        # Debug (temporary)
-        sleep 5
-        kubectl get pods -n {{workflow.parameters.app_name}}
-        kubectl get svc -n {{workflow.parameters.app_name}}
+        # Wait for pod to be ready
+        kubectl wait --for=condition=Available --timeout=300s -n {{workflow.parameters.app_name}} deploy/{{workflow.parameters.app_name}}
 
         # Temporary output until app-serving service is implemented
         # This msg will be sent to CLI by app-serviing service.

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -15,6 +15,8 @@ spec:
       value: "http://github.com/robertchoi80/sample-petclinic"
     - name: app_path
       value: "spring-petclinic-2.7.0-SNAPSHOT.jar"
+    - name: app_version
+      value: "v1.0"
     - name: port
       value: "8080"
     - name: container_registry
@@ -74,7 +76,7 @@ spec:
         sed -i "s/JARFILENAME/{{workflow.parameters.app_path}}/g" ./Dockerfile ./manifest.yaml
         sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile ./manifest.yaml
 
-        image_name="{{workflow.parameters.container_registry}}/{{workflow.parameters.app_name}}:latest"
+        image_name="{{workflow.parameters.container_registry}}/{{workflow.parameters.app_name}}:{{workflow.parameters.app_version}}"
         image_name_alt=$(echo $image_name | sed 's:/:\\\/:g')
 
         # Build docker image
@@ -110,7 +112,6 @@ spec:
         export KUBECONFIG='/etc/kubeconfig_temp'
 
         # Deploy
-        kubectl create ns {{workflow.parameters.app_name}}
         kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}}
 
         # Debug (temporary)
@@ -119,6 +120,11 @@ spec:
         kubectl get svc -n {{workflow.parameters.app_name}}
 
         # Temporary output until app-serving service is implemented
+        # This msg will be sent to CLI by app-serviing service.
         echo "The app <{{workflow.parameters.app_name}}> has been deployed successfully. Check the app endpoint as follows.
 
         $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+
+        # For demo purpose only
+        echo "Fetching app endpoint..."
+        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -63,11 +63,6 @@ spec:
         # fetch Dockerfile & manifests from git
         git clone https://github.com/openinfradev/app-serve-template.git
 
-        # Extract app_repo basename
-        #app_root=${app_repo##*\/}
-
-        ls -l .
-
         cp -r ./app-serve-template/* ./app_root/
         ls -l ./app_root/
 

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -77,7 +77,6 @@ spec:
         sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile ./base/*.yaml
 
         image_name="{{workflow.parameters.container_registry}}/{{workflow.parameters.app_name}}:{{workflow.parameters.app_version}}"
-        image_name_alt=$(echo $image_name | sed 's:/:\\\/:g')
 
         # Build docker image
         docker build -t $image_name .
@@ -99,15 +98,11 @@ spec:
         ##############
 
         # Build manifest using kustomize
-        if [[ "{{workflow.parameters.resource_spec}}" != "medium" ]]; then
-          kustomize build overlays/{{workflow.parameters.resource_spec}} > manifest.yaml
-        else
-          kustomize build base > manifest.yaml
-        fi
+        kustomize build overlays/{{workflow.parameters.resource_spec}} > manifest.yaml
 
         # replace variable for the app
         sed -i "s/APPNAME/{{workflow.parameters.app_name}}/g" ./manifest.yaml
-        sed -i "s/IMAGEURL/${image_name_alt}/g" ./manifest.yaml
+        sed -i "s#IMAGEURL#${image_name}#g" ./manifest.yaml
         sed -i "s/PROFILE/{{workflow.parameters.profile}}/g" ./manifest.yaml
 
         # Debug

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -1,0 +1,124 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: serve-java-app
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: cluster_id
+      value: "011b88fa-4d53-439f-9336-67845f994051"
+    - name: app_name
+      value: "sample-petclinic"
+    - name: app_repo
+      value: "http://github.com/robertchoi80/sample-petclinic"
+    - name: app_path
+      value: "spring-petclinic-2.7.0-SNAPSHOT.jar"
+    - name: port
+      value: "8080"
+    - name: container_registry
+      value: "docker.io/robertchoi80"
+  templates:
+  - name: main
+    volumes:
+    - name: varrun
+      emptyDir: {}
+    sidecars:
+    - name: dind
+      image: 'docker:20.10.16-dind'
+      volumeMounts:
+      - mountPath: /var/run
+        name: varrun
+      securityContext:
+        privileged: true
+    container:
+      image: 'sktcloud/appserving-worker:latest'
+      volumeMounts:
+      - mountPath: /var/run
+        name: varrun
+      env:
+      - name: DOCKERHUB_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: dockerhub-robert-token
+            key: TOKEN
+      command:
+      - /bin/sh
+      - '-exc'
+      - |
+        app_repo="{{workflow.parameters.app_repo}}"
+        mkdir -p /apps && cd /apps/
+
+        # Clone app repo (Jar file)
+        git clone ${app_repo}.git app_root
+
+        # fetch Dockerfile & manifests from git
+        git clone https://github.com/openinfradev/app-serve-template.git
+
+        # Extract app_repo basename
+        #app_root=${app_repo##*\/}
+
+        ls -l .
+
+        cp ./app-serve-template/* ./app_root/
+        ls -l ./app_root/
+
+        ###############
+        # Build Image #
+        ###############
+
+        cd /apps/app_root
+
+        # Replace port number in Dockerfile
+        sed -i "s/JARFILENAME/{{workflow.parameters.app_path}}/g" ./Dockerfile ./manifest.yaml
+        sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile ./manifest.yaml
+
+        image_name="{{workflow.parameters.container_registry}}/{{workflow.parameters.app_name}}:latest"
+        image_name_alt=$(echo $image_name | sed 's:/:\\\/:g')
+
+        # Build docker image
+        docker build -t $image_name .
+
+        # TODO: dynamically create repository in dockerhub
+        # Not urgent task since it's likely to use another registry for real service.
+
+
+
+
+        # Login to dockerhub
+        docker login -u robertchoi80 -p $DOCKERHUB_TOKEN
+
+        # Push image
+        docker push $image_name
+
+        ##############
+        # Deployment #
+        ##############
+
+        # replace variable for the app
+        sed -i "s/APPNAME/{{workflow.parameters.app_name}}/g" ./manifest.yaml
+        sed -i "s/IMAGEURL/${image_name_alt}/g" ./manifest.yaml
+
+        # Debug
+        cat Dockerfile
+        cat manifest.yaml
+
+        # Prepare kubeconfig
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        echo "$KUBECONFIG_" > /etc/kubeconfig_temp
+        export KUBECONFIG='/etc/kubeconfig_temp'
+
+        # Deploy
+        kubectl create ns {{workflow.parameters.app_name}}
+        kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}}
+
+        # Debug
+        kubectl get pods -n {{workflow.parameters.app_name}}
+        kubectl get svc -n {{workflow.parameters.app_name}}
+
+        # Temporary output until app-serving service is implemented
+        sleep 10
+        echo "The app <{{workflow.parameters.app_name}}> has been deployed successfully. Check the app endpoint as follows.
+
+$ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -21,6 +21,9 @@ spec:
       value: "8080"
     - name: profile
       value: "default"
+    # Possible values: tiny, medium, large
+    - name: resource_spec
+      value: "medium"
     - name: container_registry
       value: "docker.io/robertchoi80"
   templates:
@@ -65,7 +68,7 @@ spec:
 
         ls -l .
 
-        cp ./app-serve-template/* ./app_root/
+        cp -r ./app-serve-template/* ./app_root/
         ls -l ./app_root/
 
         ###############
@@ -75,8 +78,8 @@ spec:
         cd /apps/app_root
 
         # Replace port number in Dockerfile
-        sed -i "s/JARFILENAME/{{workflow.parameters.app_path}}/g" ./Dockerfile ./manifest.yaml
-        sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile ./manifest.yaml
+        sed -i "s/JARFILENAME/{{workflow.parameters.app_path}}/g" ./Dockerfile ./base/*.yaml
+        sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile ./base/*.yaml
 
         image_name="{{workflow.parameters.container_registry}}/{{workflow.parameters.app_name}}:{{workflow.parameters.app_version}}"
         image_name_alt=$(echo $image_name | sed 's:/:\\\/:g')
@@ -99,6 +102,13 @@ spec:
         ##############
         # Deployment #
         ##############
+
+        # Build manifest using kustomize
+        if [[ "{{workflow.parameters.resource_spec}}" != "medium" ]]; then
+          kustomize build overlays/{{workflow.parameters.resource_spec}} > manifest.yaml
+        else
+          kustomize build base > manifest.yaml
+        fi
 
         # replace variable for the app
         sed -i "s/APPNAME/{{workflow.parameters.app_name}}/g" ./manifest.yaml
@@ -124,7 +134,10 @@ spec:
         # This msg will be sent to CLI by app-serviing service.
         echo "The app <{{workflow.parameters.app_name}}> has been deployed successfully. Check the app endpoint as follows.
 
-        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+        # Endpoint
+        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+        # Port number
+        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.spec.ports[0].port}'"
 
         # For demo purpose only
         echo "Fetching app endpoint..."

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -19,6 +19,8 @@ spec:
       value: "v1.0"
     - name: port
       value: "8080"
+    - name: profile
+      value: "default"
     - name: container_registry
       value: "docker.io/robertchoi80"
   templates:
@@ -101,6 +103,7 @@ spec:
         # replace variable for the app
         sed -i "s/APPNAME/{{workflow.parameters.app_name}}/g" ./manifest.yaml
         sed -i "s/IMAGEURL/${image_name_alt}/g" ./manifest.yaml
+        sed -i "s/PROFILE/{{workflow.parameters.profile}}/g" ./manifest.yaml
 
         # Debug
         cat Dockerfile

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -113,12 +113,12 @@ spec:
         kubectl create ns {{workflow.parameters.app_name}}
         kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}}
 
-        # Debug
+        # Debug (temporary)
+        sleep 5
         kubectl get pods -n {{workflow.parameters.app_name}}
         kubectl get svc -n {{workflow.parameters.app_name}}
 
         # Temporary output until app-serving service is implemented
-        sleep 10
         echo "The app <{{workflow.parameters.app_name}}> has been deployed successfully. Check the app endpoint as follows.
 
-$ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"

--- a/dockerfiles/Dockerfile.appserving-worker
+++ b/dockerfiles/Dockerfile.appserving-worker
@@ -1,0 +1,13 @@
+FROM docker:20.10.16-git
+
+MAINTAINER Cloud Co, SK Telecom
+
+USER root
+
+RUN apk add --no-cache curl
+
+# Install kubectl
+RUN curl -Lo /usr/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN chmod +x /usr/bin/kubectl
+
+CMD ["sh"]

--- a/dockerfiles/Dockerfile.appserving-worker
+++ b/dockerfiles/Dockerfile.appserving-worker
@@ -4,10 +4,14 @@ MAINTAINER Cloud Co, SK Telecom
 
 USER root
 
-RUN apk add --no-cache curl
+RUN apk add --no-cache curl bash
 
 # Install kubectl
 RUN curl -Lo /usr/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
 RUN chmod +x /usr/bin/kubectl
+
+# Install kustomize
+RUN curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+RUN mv kustomize /usr/bin/
 
 CMD ["sh"]


### PR DESCRIPTION
app-serving MVP 시연을 위한 workflow 초안 추가합니다. 
우선 신속한 구현을 위해 하나의 step으로 구성되어 있고, 향후 실제 서비스시에는 API 분할에 따라 step이 나뉘어질 것으로 보입니다. 
app profile 선택하는 부분도 현재는 빠져있고 향후 추가 예정입니다.  -> 추가 완료
(update) resource spec도 추가 완료

template은 https://github.com/openinfradev/app-serve-template 에 있습니다.

<참고사항>
- 바로 테스트해보실 수 있게 sample java app을 빌드해놓은 제 개인 repo url 을 default param으로 넣어두었습니다. 
- dockerhub 상에 동적으로 repository를 만들어주어야 100% 자동화가 될텐데, 그부분은 현재 수동으로 수행하였습니다. (차후 harbor 등 다른 Registry를 쓸 수도 있으므로 굳이 Dockerhub API 써서 repo 생성하는 노가다는 하지 않았습니다)
- 마지막의 endpoint 보여주는 부분은 실제 서비스에선 app-serving-LCM 에서 app-serving-CLI로 전달해서 보여줄 내용인데, 아직 해당 컴포넌트들이 없기에 임시로 workflow에 넣어두었습니다. 