### PR TITLE
Supports template configuration with different infrastructure providers

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -137,7 +137,9 @@ spec:
             echo "[$date] $level     $msg"
           }
 
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 
@@ -183,7 +185,8 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 

--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -114,7 +114,8 @@ spec:
           kube_params=""
 
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+            kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
 

--- a/deploy_apps/tks-remove-servicemesh-wftpl.yaml
+++ b/deploy_apps/tks-remove-servicemesh-wftpl.yaml
@@ -71,7 +71,8 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+            kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
             kube_params+="--kubeconfig=/etc/kubeconfig"

--- a/deploy_apps/tks-service-mesh-dashboard-wftpl.yaml
+++ b/deploy_apps/tks-service-mesh-dashboard-wftpl.yaml
@@ -828,7 +828,8 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+            kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -936,7 +937,8 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+            kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -1019,7 +1021,8 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+            kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -1149,7 +1152,8 @@ spec:
         - |
           mkdir ~/.kube
           cp /kube/value ~/.kube/config_adm
-          KUBECONFIG_USERCLUSTER=$(kubectl --kubeconfig ~/.kube/config_adm get secret -n ${CLUSTER_ID} ${CLUSTER_ID}-kubeconfig -o=jsonpath='{.data.value}' | base64 -d)
+          USER_CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          KUBECONFIG_USERCLUSTER=$(kubectl --kubeconfig ~/.kube/config_adm get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig_workload:\n$KUBECONFIG_USERCLUSTER" | head -n 5
           cat <<< "$KUBECONFIG_USERCLUSTER" > ~/.kube/config_user
 
@@ -1203,9 +1207,6 @@ spec:
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"
-      env:
-        - name: CLUSTER_ID
-          value: "{{workflow.parameters.cluster_id}}"
     activeDeadlineSeconds: 900
     retryStrategy:
       limit: 2

--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -13,8 +13,6 @@ spec:
       value: "cluster_uuid"
     - name: template_name
       value: "template-std"
-    - name: infra_provider
-      value: "aws"
 
   templates:
   - name: createClusterRepo
@@ -37,8 +35,13 @@ spec:
 
         git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CONTRACT_ID}.git
 
+        # Get cluster-api infra provider in the template
+        infra_provider_group="$(ls ${CONTRACT_ID}/$TEMPLATE_NAME | grep -v tks-cluster-common | grep tks-cluster)"
+        INFRA_PROVIDER=${infra_provider_group#tks-cluster-}
+        echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
+
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
-        cp -r ${CONTRACT_ID}/.github ${CLUSTER_ID}/.github
+        cp -r ${CONTRACT_ID}/_github ${CLUSTER_ID}/.github
 
         echo $CLUSTER_INFO
 
@@ -120,10 +123,20 @@ spec:
         value: "{{workflow.parameters.cluster_id}}"
       - name: TEMPLATE_NAME
         value: "{{workflow.parameters.template_name}}"
-      - name: INFRA_PROVIDER
-        value: "{{workflow.parameters.infra_provider}}"
       - name: CLUSTER_INFO
         value: "{{inputs.parameters.cluster_info}}"
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: infra_provider
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/infra_provider.txt
 
   - name: createRepoCredential
     activeDeadlineSeconds: 120
@@ -165,3 +178,9 @@ spec:
       - - name: createRepoCredential
           template: createRepoCredential
           arguments: {}
+
+    outputs:
+      parameters:
+      - name: infra_provider
+        valueFrom:
+          parameter: "{{steps.createClusterRepo.outputs.parameters.infra_provider}}"

--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -42,13 +42,16 @@ spec:
         INFRA_PROVIDER=${infra_provider_group#tks-cluster-}
         echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
 
+        # We se only the first UUID group for the cluster name and namespace.
+        CLUSTER_NAME=${CLUSTER_ID%%-*}
+
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
         cp -r ${CONTRACT_ID}/_github ${CLUSTER_ID}/.github
 
         echo $CLUSTER_INFO
 
         ## Replace site-values with fetched params ##
-        sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-common/site-values.yaml
+        sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_NAME/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-common/site-values.yaml
         case $INFRA_PROVIDER in
           aws)
             ## Fetch cluster params from cluster_info file ##
@@ -61,7 +64,7 @@ spec:
             val_max_size=$(echo $CLUSTER_INFO | sed 's/.*\(max_size_per_az:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
             echo "max_size_per_az: $val_max_size"
 
-            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
+            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_NAME/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
             sed -i "s/sshKeyName:\ CHANGEME/sshKeyName: $val_ssh_key/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
             sed -i "s/clusterRegion:\ CHANGEME/clusterRegion: $val_region/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
             sed -i "s/mdNumOfAz:\ CHANGEME/mdNumOfAz: $val_num_of_az/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
@@ -71,7 +74,7 @@ spec:
             ;;
 
           byoh)
-            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-byoh/site-values.yaml
+            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_NAME/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-byoh/site-values.yaml
             echo "BYOH"
             ;;
 

--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -13,6 +13,8 @@ spec:
       value: "cluster_uuid"
     - name: template_name
       value: "template-std"
+    - name: test_template_name
+      value: "aws-reference"
 
   templates:
   - name: createClusterRepo
@@ -122,7 +124,7 @@ spec:
       - name: CLUSTER_ID
         value: "{{workflow.parameters.cluster_id}}"
       - name: TEMPLATE_NAME
-        value: "{{workflow.parameters.template_name}}"
+        value: "{{workflow.parameters.test_template_name}}"
       - name: CLUSTER_INFO
         value: "{{inputs.parameters.cluster_info}}"
       volumeMounts:

--- a/github_repo/create-contract-repo.yaml
+++ b/github_repo/create-contract-repo.yaml
@@ -37,14 +37,19 @@ spec:
         git clone -b ${REVISION} https://github.com/openinfradev/decapod-site
 
         cd decapod-site
+
+        mv .github _github
+
         # TODO: support to use decapod-reference-offline later?
-        mv decapod-reference template-std
+        rm -rf decapod-reference
         rm -rf decapod-reference-offline
+
         # Remove unnecessary app_group directory before commit.
         # If these kinds of apps increases, then they might be defined as black list
         # and then removed by FOR loop iteration.
         # For now, this hardcoding seems enough.
-        rm -rf template-std/openstack template-std/decapod-controller
+        rm -rf aws-reference/openstack aws-reference/decapod-controller aws-reference/admin-tools
+        rm -rf byoh-reference/openstack byoh-reference/decapod-controller byoh-reference/admin-tools
 
         sed -i "s/BRANCH=\"main\"/BRANCH=\"${REVISION}\"/g" .github/workflows/render-cd.sh
 

--- a/tests/validate-service-wftpl.yaml
+++ b/tests/validate-service-wftpl.yaml
@@ -35,7 +35,8 @@ spec:
         - /bin/bash
         - -c
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          KUBECONFIG_=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 
@@ -80,7 +81,8 @@ spec:
         - /bin/bash
         - -c
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          KUBECONFIG_=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 

--- a/tests/validate-usercluster-wftpl.yaml
+++ b/tests/validate-usercluster-wftpl.yaml
@@ -36,7 +36,9 @@ spec:
         - /bin/bash
         - '-exc'
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          KUBECONFIG_=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -11,8 +11,6 @@ spec:
       value: "0010010a-d6cb-459b-9148-1b02ac545753"
     - name: cluster_id
       value: "011b88fa-4d53-439f-9336-67845f994051"
-    - name: infra_provider
-      value: "aws" # aws or byoh
     - name: site_name
       value: "{{ workflow.parameters.cluster_id }}"
     - name: template_name
@@ -60,7 +58,7 @@ spec:
           - name: cluster_info
             value: "{{steps.tks-get-cluster-info.outputs.parameters.cluster_info}}"
 
-    - - name: k8s-by-capi
+    - - name: k8s-by-aws
         templateRef:
           name: create-application
           template: installApps
@@ -76,7 +74,7 @@ spec:
                   "target_cluster": "tks-admin"
                 }
               ]
-        when: "{{workflow.parameters.infra_provider}} == aws"
+        when: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws"
 
     - - name: k8s-by-byoh
         templateRef:
@@ -94,10 +92,16 @@ spec:
                   "target_cluster": "tks-admin"
                 }
               ]
-        when: "{{workflow.parameters.infra_provider}} == byoh"
+        when: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == byoh"
 
     - - name: init-cluster-for-tks
         template: init-cluster-for-tks
+        arguments:
+          parameters:
+            - name: cluster_id
+              value: "{{ workflow.parameters.cluster_id }}"
+            - name: infra_provider
+              value: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}}"
 
     - - name: install-cluster-autoscaler-rbac
         templateRef:
@@ -179,18 +183,22 @@ spec:
                   "target_cluster": ""
                 }
               ]
-        when: "{{workflow.parameters.infra_provider}} == aws"
+        when: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws"
 
     - - name: create-internal-communication
         templateRef:
           name: manage-internal-communication
           template: deploy
-        when: "{{workflow.parameters.infra_provider}} == aws"
+        when: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws"
 
   #######################
   # Template Definition #
   #######################
   - name: init-cluster-for-tks
+    inputs:
+      parameters:
+        - name: cluster_id
+        - name: infra_provider
     container:
       name: cluster-init
       image: 'ghcr.io/openinfradev/python_kubectl_argo:v1.1.0'
@@ -273,9 +281,9 @@ spec:
           name: "decapod-argocd-config"
       env:
       - name: CLUSTER_ID
-        value: "{{ workflow.parameters.cluster_id }}"
+        value: "{{ inputs.parameters.cluster_id }}"
       - name: INFRA_PROVIDER
-        value: "{{ workflow.parameters.infra_provider }}"
+        value: "{{ inputs.parameters.infra_provider }}"
       - name: TKS_NODE_NAME
         value: "taco"
 

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -15,6 +15,8 @@ spec:
       value: "{{ workflow.parameters.cluster_id }}"
     - name: template_name
       value: "template-std"
+    - name: test_template_name
+      value: "aws-reference"
     - name: git_account
       value: "tks-management"
     - name: manifest_repo_url

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -211,35 +211,43 @@ spec:
           cp /kube/value kubeconfig_adm
           export KUBECONFIG=kubeconfig_adm
 
-          kubectl wait --for=condition=Available --timeout=600s kcp -n $CLUSTER_ID $CLUSTER_ID-control-plane
+          CLUSTER_NAME=${CLUSTER_ID%%-*}
 
-          KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          kubectl wait --for=condition=Available --timeout=600s kcp -n $CLUSTER_NAME $CLUSTER_NAME-control-plane
+
+          KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_WORKLOAD" > kubeconfig_workload
 
           case $INFRA_PROVIDER in
             aws)
               echo "Wait for machinepoool $1-$2-mp-0 generated"
-              while [ $(kubectl get machinepool -n $CLUSTER_ID $CLUSTER_ID-$TKS_NODE_NAME-mp-0 --ignore-not-found | wc -l) == 0 ]
+              while [ $(kubectl get machinepool -n $CLUSTER_NAME $CLUSTER_NAME-$TKS_NODE_NAME-mp-0 --ignore-not-found | wc -l) == 0 ]
               do
                 echo "Wait for machinepools deployed (1s)"
                 sleep 1
               done
 
-              desired_replicas=$(kubectl get machinepool -n $CLUSTER_ID $CLUSTER_ID-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.spec.replicas}' )
-              while [ $(kubectl get machinepool -n $CLUSTER_ID $CLUSTER_ID-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.status.nodeRefs}' | jq '.[].uid' | wc -l) != $desired_replicas ]
+              desired_replicas=$(kubectl get machinepool -n $CLUSTER_NAME $CLUSTER_NAME-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.spec.replicas}' )
+              while [ $(kubectl get machinepool -n $CLUSTER_NAME $CLUSTER_NAME-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.status.nodeRefs}' | jq '.[].uid' | wc -l) != $desired_replicas ]
               do
                 echo "Wait for instance is ready (1s)"
                 sleep 1
               done
 
-              for node in $(kubectl get machinepool -n $CLUSTER_ID $CLUSTER_ID-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.status.nodeRefs}'| jq -r '.[].name')
+              for node in $(kubectl get machinepool -n $CLUSTER_NAME $CLUSTER_NAME-$TKS_NODE_NAME-mp-0 -o=jsonpath='{.status.nodeRefs}'| jq -r '.[].name')
               do
                 kubectl --kubeconfig=kubeconfig_workload label node $node taco-lma=enabled taco-ingress-gateway=enabled taco-egress-gateway=enabled servicemesh=enabled --overwrite
               done
               ;;
 
             byoh)
-              echo "BYOH"
+              ### XXX: workaroud for "etcdserver: leader changed" failure
+              kubectl wait --for=condition=Ready --timeout=600s kcp -n $CLUSTER_NAME $CLUSTER_NAME-control-plane
+
+              for node in $(kubectl get machine -n $CLUSTER_NAME -l cluster.x-k8s.io/cluster-name=$CLUSTER_NAME,cluster.x-k8s.io/deployment-name=$CLUSTER_NAME-md-$TKS_NODE_NAME -o=jsonpath='{.items[*].status.nodeRef.name}')
+              do
+                kubectl --kubeconfig=kubeconfig_workload label node $node taco-lma=enabled taco-ingress-gateway=enabled taco-egress-gateway=enabled servicemesh=enabled --overwrite
+              done
               ;;
 
             *)
@@ -298,17 +306,18 @@ spec:
         - '-exc'
         - |
           cp /kube/value kubeconfig
+          USER_CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
 
           CLUSTER=$(kubectl --kubeconfig kubeconfig get cl -ojsonpath='{.items[0].metadata.name}' -n default)
           ADMIN_USER=${CLUSTER}-admin
-          TOKEN=$(kubectl --kubeconfig kubeconfig get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl --kubeconfig kubeconfig get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
+          TOKEN=$(kubectl --kubeconfig kubeconfig get secrets -n $USER_CLUSTER_NAME "$(kubectl --kubeconfig kubeconfig get sa cluster-autoscaler -n $USER_CLUSTER_NAME -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
           kubectl --kubeconfig kubeconfig config set-credentials cluster-autoscaler --token=$TOKEN
           kubectl --kubeconfig kubeconfig config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
           kubectl --kubeconfig kubeconfig config use-context cluster-autoscaler
           kubectl --kubeconfig kubeconfig config delete-context "$ADMIN_USER@$CLUSTER"
           kubectl --kubeconfig kubeconfig config delete-user "$ADMIN_USER"
 
-          KUBECONFIG_WORKLOAD=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_WORKLOAD=$(kubectl get secret -n $USER_CLUSTER_NAME $USER_CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig_workload:\n$KUBECONFIG_WORKLOAD" | head -n 5
           cat <<< "$KUBECONFIG_WORKLOAD" > kubeconfig_workload
 
@@ -325,7 +334,8 @@ spec:
         - /bin/bash
         - '-exc'
         - |
-          KUBECONFIG=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          KUBECONFIG=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig:\n$KUBECONFIG" | head -n 5
           cat <<< "$KUBECONFIG" > kubeconfig_temp
 

--- a/tks-cluster/manage-internal-communication.yaml
+++ b/tks-cluster/manage-internal-communication.yaml
@@ -67,7 +67,7 @@ spec:
 
       env:
       - name: cluster_id
-        value: "{{workflow.parameters.cluster_id}}"
+        value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"
@@ -105,7 +105,7 @@ spec:
         aws ec2 delete-security-group --group-id $SG
       env:
       - name: cluster_id
-        value: "{{workflow.parameters.cluster_id}}"
+        value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"
@@ -132,7 +132,7 @@ spec:
 
       env:
       - name: cluster_id
-        value: "{{workflow.parameters.cluster_id}}"
+        value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -33,6 +33,13 @@ spec:
   templates:
   - name: main
     steps:
+    - - name: findInfraProvider
+        template: findInfraProvider
+        arguments:
+          parameters:
+            - name: cluster_id
+              value: "{{workflow.parameters.cluster_id}}"
+
     - - name: disableAutoSync
         template: disableAutoSync
 
@@ -88,7 +95,7 @@ spec:
         templateRef:
           name: manage-internal-communication
           template: DeleteInternalCon
-        when: "{{workflow.parameters.infra_provider}} == aws"
+        when: "{{steps.findInfraProvider.outputs.parameters.infra_provider}} == aws"
 
     - - name: deleteCsiDriverApp
         templateRef:
@@ -98,7 +105,7 @@ spec:
           parameters:
             - name: app_name
               value: "{{workflow.parameters.app_prefix}}-aws-ebs-csi-driver"
-        when: "{{workflow.parameters.infra_provider}} == aws"
+        when: "{{steps.findInfraProvider.outputs.parameters.infra_provider}} == aws"
 
     - - name: deleteCalicoController
         template: deleteCalicoController
@@ -137,6 +144,44 @@ spec:
   #######################
   # Template Definition #
   #######################
+  - name: findInfraProvider
+    activeDeadlineSeconds: 300
+    inputs:
+      parameters:
+      - name: cluster_id
+    container:
+      name: 'createClusterRepo'
+      image: ghcr.io/sktelecom/ghcli-alpine:2.0.0
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CLUSTER_ID}.git
+
+        # Get cluster-api infra provider in the cluster
+        infra_provider_group="$(ls ${CLUSTER_ID}/$CLUSTER_ID | grep -v tks-cluster-common | grep tks-cluster)"
+        INFRA_PROVIDER=${infra_provider_group#tks-cluster-}
+        echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
+      envFrom:
+        - secretRef:
+            name: "github-tks-mgmt-token"
+      env:
+      - name: CLUSTER_ID
+        value: "{{inputs.parameters.cluster_id}}"
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: infra_provider
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/infra_provider.txt
+
   - name: disableAutoSync
     container:
       name: disable-auto-sync

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -88,6 +88,7 @@ spec:
         templateRef:
           name: manage-internal-communication
           template: DeleteInternalCon
+        when: "{{workflow.parameters.infra_provider}} == aws"
 
     - - name: deleteCsiDriverApp
         templateRef:
@@ -97,6 +98,7 @@ spec:
           parameters:
             - name: app_name
               value: "{{workflow.parameters.app_prefix}}-aws-ebs-csi-driver"
+        when: "{{workflow.parameters.infra_provider}} == aws"
 
     - - name: deleteCalicoController
         template: deleteCalicoController

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -128,7 +128,7 @@ spec:
         arguments:
           parameters:
             - name: target_namespace
-              value: "{{workflow.parameters.cluster_id}}"
+              value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"
 
     - - name: deleteArgoCDAppGroup
         templateRef:
@@ -212,7 +212,8 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 
@@ -242,7 +243,8 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          CLUSTER_NAME={{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}
+          kube_secret=$(kubectl get secret -n $CLUSTER_NAME $CLUSTER_NAME-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 
@@ -288,4 +290,4 @@ spec:
         - name: TARGET_NAMESPACE
           value: "{{inputs.parameters.target_namespace}}"
         - name: CLUSTER_NAME
-          value: "{{workflow.parameters.cluster_id}}"
+          value: "{{=sprig.substr(0, 8, workflow.parameters.cluster_id)}}"


### PR DESCRIPTION
템플릿 사이트의 인프라 프로바이더 그룹 (tks-cluster-aws or tks-cluster-byoh) 디렉토리를 기준으로 인프라 프로바이더 정보를 얻어서 이후 클러스터 설치 과정에서 사용하도록 하였습니다.

TKS cli는 'template-std' 라는 템플릿 명을 하드코딩 되어 사용하기 있기 때문에 aws, byoh 인프라 프로바이더를 임시적으로 선택해서 설치하기 위해서 https://github.com/openinfradev/tks-flow/commit/a609f1c9faa493169759e84c375fea5ebf44bc30 를 추가하였고 TKS cli에서 클러스터 생성 명령어```tks create cluster```에 템플릿 지정 플래그가 추가되면 되돌리도록 하겠습니다.

**추가 반영한 내용이 있어 업데이트합니다 (2022/06/29)**
- tks cluster lcm에서 infra provider 정보를 유지하지 않기 때문에 임시적으로 삭제 과정에서 내부적으로 인프라 프로바이더 정보를 확인해서 사용하도록 하였습니다: adc6902fa7357116c6012f79039d09dec684b4d9
- cluster-api 를 통해 배포되는 클러스터의 이름을 기존 UUID 모두에서 첫번 째 그룹 (8글자)만 사용하도록 하였습니다: 7093056b33ee64331a68cd6ffa399791cc5fd442

-----

생성되는 클러스터의 인프라 프로바이더 변경을 위해서  ```tks create cluster``` 실행 전 다음 값을 먼저 변경해야 합니다.
- tks-cluster/create-usercluster-wftpl.yaml: test_template_name 파라미터 기본 값 변경 (aws-reference or byoh-reference)
 - ~~remove-usercluster-wftpl.yaml: infra_provider 파라미터 기본 값 변경 (aws or byoh)~~