### PR TITLE
using structured kustomize document on infra-selection

### DIFF
--- a/deploy_apps/tks-ingress-controller-wftpl.yaml
+++ b/deploy_apps/tks-ingress-controller-wftpl.yaml
@@ -39,5 +39,5 @@ spec:
           - name: list
             value: |
               [
-                { "app_group": "tks-cluster-common", "path": "ingress-nginx", "namespace": "taco-system", "target_cluster": "" }
+                { "app_group": "tks-cluster", "path": "ingress-nginx", "namespace": "taco-system", "target_cluster": "" }
               ]

--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -38,8 +38,7 @@ spec:
         git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CONTRACT_ID}.git
 
         # Get cluster-api infra provider in the template
-        infra_provider_group="$(ls ${CONTRACT_ID}/$TEMPLATE_NAME | grep -v tks-cluster-common | grep tks-cluster)"
-        INFRA_PROVIDER=${infra_provider_group#tks-cluster-}
+        INFRA_PROVIDER="$(cat ${CONTRACT_ID}/$TEMPLATE_NAME/tks-cluster/kustomization.yaml | grep /infra/ | awk -F \/ '{print $3}')"
         echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
 
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
@@ -48,7 +47,7 @@ spec:
         echo $CLUSTER_INFO
 
         ## Replace site-values with fetched params ##
-        sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-common/site-values.yaml
+        sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
         case $INFRA_PROVIDER in
           aws)
             ## Fetch cluster params from cluster_info file ##
@@ -61,17 +60,17 @@ spec:
             val_max_size=$(echo $CLUSTER_INFO | sed 's/.*\(max_size_per_az:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
             echo "max_size_per_az: $val_max_size"
 
-            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/sshKeyName:\ CHANGEME/sshKeyName: $val_ssh_key/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/clusterRegion:\ CHANGEME/clusterRegion: $val_region/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/mdNumOfAz:\ CHANGEME/mdNumOfAz: $val_num_of_az/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/mdMinSizePerAz:\ CHANGEME/mdMinSizePerAz: $val_min_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/mdMaxSizePerAz:\ CHANGEME/mdMaxSizePerAz: $val_max_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
-            sed -i "s/mdMachineType:\ CHANGEME/mdMachineType: $val_machine_type/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-aws/site-values.yaml
+            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/sshKeyName:\ CHANGEME/sshKeyName: $val_ssh_key/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/clusterRegion:\ CHANGEME/clusterRegion: $val_region/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/mdNumOfAz:\ CHANGEME/mdNumOfAz: $val_num_of_az/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/mdMinSizePerAz:\ CHANGEME/mdMinSizePerAz: $val_min_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/mdMaxSizePerAz:\ CHANGEME/mdMaxSizePerAz: $val_max_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            sed -i "s/mdMachineType:\ CHANGEME/mdMachineType: $val_machine_type/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             ;;
 
           byoh)
-            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster-byoh/site-values.yaml
+            sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             echo "BYOH"
             ;;
 

--- a/github_repo/render-manifests.yaml
+++ b/github_repo/render-manifests.yaml
@@ -138,10 +138,10 @@ spec:
 
           if [[ ${SITE_NAME} != *"decapod"* ]]; then
             log 0 "INFO" "Almost finished: changing namespace for aws-cluster-resouces from argo to cluster-name.."
-            sed -i "s/ namespace: argo/ namespace: ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster-aws/cluster-api-aws/*
-            sed -i "s/ - argo/ - ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster-aws/cluster-api-aws/*
+            sed -i "s/ namespace: argo/ namespace: ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/*
+            sed -i "s/- argo/- ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/*
             # It's possible besides of two above but very tricky!!
-            # sed -i "s/ argo$/ ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster-aws/cluster-api-aws/*
+            # sed -i "s/ argo$/ ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/*
             echo "---
         apiVersion: v1
         kind: Namespace
@@ -152,7 +152,7 @@ spec:
             # It bring the secret 'dacapod-argocd-config' using kubed
             decapod-argocd-config: enabled
         " > Namespace_aws_rc.yaml
-            mv Namespace_aws_rc.yaml $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster-aws/cluster-api-aws/
+            mv Namespace_aws_rc.yaml $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/
           fi
 
         done

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -70,7 +70,7 @@ spec:
             value: |
               [
                 { 
-                  "app_group": "tks-cluster-aws",
+                  "app_group": "tks-cluster",
                   "path": "cluster-api-aws",
                   "namespace": "argo",
                   "target_cluster": "tks-admin"
@@ -88,7 +88,7 @@ spec:
             value: |
               [
                 {
-                  "app_group": "tks-cluster-byoh",
+                  "app_group": "tks-cluster",
                   "path": "cluster-api-byoh",
                   "namespace": "argo",
                   "target_cluster": "tks-admin"
@@ -115,7 +115,7 @@ spec:
             value: |
               [
                 {
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "cluster-autoscaler-rbac",
                   "namespace": "argo",
                   "target_cluster": "tks-admin"
@@ -138,31 +138,31 @@ spec:
             value: |
               [
                 { 
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "kubernetes-addons",
                   "namespace": "taco-system",
                   "target_cluster": ""
                 },
                 {
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "ingress-nginx",
                   "namespace": "taco-system",
                   "target_cluster": ""
                 },
                 {
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "metrics-server",
                   "namespace": "kube-system",
                   "target_cluster": ""
                 },
                 {
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "cluster-autoscaler",
                   "namespace": "kube-system",
                   "target_cluster": ""
                 },
                 {
-                  "app_group": "tks-cluster-common",
+                  "app_group": "tks-cluster",
                   "path": "kubed",
                   "namespace": "taco-system",
                   "target_cluster": ""
@@ -179,7 +179,7 @@ spec:
             value: |
               [
                 {
-                  "app_group": "tks-cluster-aws",
+                  "app_group": "tks-cluster",
                   "path": "aws-ebs-csi-driver",
                   "namespace": "kube-system",
                   "target_cluster": ""

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -160,8 +160,7 @@ spec:
         git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CLUSTER_ID}.git
 
         # Get cluster-api infra provider in the cluster
-        infra_provider_group="$(ls ${CLUSTER_ID}/$CLUSTER_ID | grep -v tks-cluster-common | grep tks-cluster)"
-        INFRA_PROVIDER=${infra_provider_group#tks-cluster-}
+        INFRA_PROVIDER="$(cat ${CONTRACT_ID}/$TEMPLATE_NAME/tks-cluster/kustomization.yaml | grep /infra/ | awk -F \/ '{print $3}')"
         echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
       envFrom:
         - secretRef:


### PR DESCRIPTION
kustomize의  다수의 리소스를 합치는 기능을 활용하여 다양한 변형을 지원할수 있다.
tks-cluster를 만드는 부분에서 infra를 함께 선택하여 aws나 byoh에 적용가능하다. (kustomization.yaml 작성시 포함한다. 다음은 aws 예시)

```
$  cat cluster/kustomization.yaml
resources:
  - ../base
  - ../infra/aws

transformers:
  - site-values.yaml
```

다음 두 pr이 동시 merge되어야 함
- https://github.com/openinfradev/decapod-site/pull/92
- https://github.com/openinfradev/decapod-base-yaml/pull/167
- https://github.com/openinfradev/tks-flow/pull/105
- https://github.com/openinfradev/decapod-flow/pull/96