### PR TITLE
update app-serving workflow

### DIFF
--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: argo
 spec:
   entrypoint: main
+  onExit: exit-handler
   arguments:
     parameters:
     # Param "task_type"
@@ -33,33 +34,68 @@ spec:
     - name: resource_spec
       value: "medium"
     - name: tks_info_host
-      value: ""
+      value: "tks-info.tks"
 
   templates:
+  - name: exit-handler
+    steps:
+    - - name: parse-failed-step
+        template: parse-failed-step
+        when: "{{workflow.status}} != Succeeded"
+# This expression syntax doesn't work at all as mentioned in the doc as always. Go to hell!
+#    - - name: notify-failure
+#        templateRef:
+#          name: update-asa-status
+#          template: updateAsaStatus
+#        arguments:
+#          parameters:
+#          - name: status
+#            valueFrom:
+#              expression: "steps['parse-failed-step'].outputs.parameters.step_name == build-image ? BUILD_FAILED : DEPLOY_FAILED"
+#        when: "{{workflow.status}} != Succeeded"
+    - - name: notify-build-failure
+        templateRef:
+          name: update-asa-status
+          template: updateAsaStatus
+        arguments:
+          parameters:
+          - name: status
+            value: "BUILD_FAILED"
+        when: "{{workflow.status}} != Succeeded && {{steps.parse-failed-step.outputs.parameters.step_name}} == build-image"
+    - - name: notify-deploy-failure
+        templateRef:
+          name: update-asa-status
+          template: updateAsaStatus
+        arguments:
+          parameters:
+          - name: status
+            value: "DEPLOY_FAILED"
+        when: "{{workflow.status}} != Succeeded && {{steps.parse-failed-step.outputs.parameters.step_name}} == deploy-app"
+
   - name: main
     steps:
     - - name: build-image
         when: "{{workflow.parameters.task_type}} != 'deploy'"
         template: build-image
-#    - - name: updateAsaStatusToTksInfo
-#        templateRef:
-#          name: update-asa-status
-#          template: updateAsaStatus
-#        arguments:
-#          parameters:
-#          - name: status
-#            value: "BUILD_SUCCESS"
+    - - name: notify-build-success
+        templateRef:
+          name: update-asa-status
+          template: updateAsaStatus
+        arguments:
+          parameters:
+          - name: status
+            value: "BUILD_SUCCESS"
     - - name: deploy-app
         when: "{{workflow.parameters.task_type}} != 'build'"
         template: deploy-app
-#    - - name: updateAsaStatusToTksInfo
-#        templateRef:
-#          name: update-asa-status
-#          template: updateAsaStatus
-#        arguments:
-#          parameters:
-#          - name: status
-#            value: "DEPLOY_SUCCESS"
+    - - name: notify-deploy-success
+        templateRef:
+          name: update-asa-status
+          template: updateAsaStatus
+        arguments:
+          parameters:
+          - name: status
+            value: "DEPLOY_SUCCESS"
 
   #######################
   # Template Definition #
@@ -193,3 +229,45 @@ spec:
         # For demo purpose only
         echo "Fetching app endpoint..."
         kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /apps/endpoint
+
+  - name: parse-failed-step
+    volumes:
+    - name: out
+      emptyDir: {}
+    outputs:
+      parameters:
+      - name: step_name
+        valueFrom:
+          path: /mnt/out/failed_step_name.txt
+    script:
+      image: python:alpine3.8
+      volumeMounts:
+      - name: out
+        mountPath: /mnt/out
+      command: [python]
+      source: |
+        import time
+        import json
+
+        wf_failures = {{workflow.failures}}
+
+        # convert string to list
+        wf_failure_list = json.loads(wf_failures)
+        print(type(wf_failure_list))
+
+        failed_step=''
+        for step in wf_failure_list:
+          print("Processing str: {}".format(step))
+          # step is 'dict' type now.
+          if step["templateName"] == 'build-image' or step["templateName"] == 'deploy-app':
+            print("found failed step {}".format(step["templateName"]))
+            failed_step = step["templateName"]
+            break
+
+        if failed_step:
+          print("Writing failed step name '{}' to file...".format(failed_step))
+          with open('/mnt/out/failed_step_name.txt', 'w') as f:
+            f.write(failed_step)
+        else:
+          print("Couldn't find failed step name!")
+          exit(1)

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -32,6 +32,8 @@ spec:
     # Possible values: tiny, medium, large
     - name: resource_spec
       value: "medium"
+    - name: tks_info_host
+      value: ""
 
   templates:
   - name: main

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -11,14 +11,12 @@ spec:
     # options: build/deploy/all
     - name: task_type
       value: "all"
-    - name: cluster_id
+    - name: target_cluster
       value: "C011b88fa"
     - name: app_name
       value: "sample-petclinic"
-    - name: app_repo
-      value: "http://github.com/robertchoi80/sample-petclinic"
-    - name: app_path
-      value: "spring-petclinic-2.7.0-SNAPSHOT.jar"
+    - name: artifact_url
+      value: "http://github.com/robertchoi80/sample-petclinic/spring-petclinic-2.7.0-SNAPSHOT.jar"
     - name: image_url
       value: "REGISTRY/IMAGE:TAG"
     - name: port
@@ -41,9 +39,25 @@ spec:
     - - name: build-image
         when: "{{workflow.parameters.task_type}} != 'deploy'"
         template: build-image
+#    - - name: updateAsaStatusToTksInfo
+#        templateRef:
+#          name: update-asa-status
+#          template: updateAsaStatus
+#        arguments:
+#          parameters:
+#          - name: status
+#            value: "BUILD_SUCCESS"
     - - name: deploy-app
         when: "{{workflow.parameters.task_type}} != 'build'"
         template: deploy-app
+#    - - name: updateAsaStatusToTksInfo
+#        templateRef:
+#          name: update-asa-status
+#          template: updateAsaStatus
+#        arguments:
+#          parameters:
+#          - name: status
+#            value: "DEPLOY_SUCCESS"
 
   #######################
   # Template Definition #
@@ -76,26 +90,23 @@ spec:
       - /bin/sh
       - '-exc'
       - |
-        app_repo="{{workflow.parameters.app_repo}}"
         mkdir -p /apps && cd /apps/
 
-        # Clone app repo (Jar file)
-        git clone ${app_repo}.git app_root
+        # TODO: How to pass auth info here?
+        curl -L -o {{workflow.parameters.app_name}}.jar {{workflow.parameters.artifact_url}}
 
         # fetch Dockerfile & manifests from git
         git clone https://github.com/openinfradev/app-serve-template.git
 
-        cp -r ./app-serve-template/Dockerfile ./app_root/
-        ls -l ./app_root/
+        cp -r ./app-serve-template/Dockerfile .
+        ls -l .
 
         ###############
         # Build Image #
         ###############
 
-        cd /apps/app_root
-
         # Replace port number in Dockerfile
-        sed -i "s/JARFILENAME/{{workflow.parameters.app_path}}/g" ./Dockerfile
+        sed -i "s/JARFILENAME/{{workflow.parameters.app_name}}.jar/g" ./Dockerfile
         sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile
 
         # Debug
@@ -112,6 +123,11 @@ spec:
         docker push $image_name
 
   - name: deploy-app
+    #    outputs:
+    #      parameters:
+    #      - name: endpoint_url
+    #        valueFrom:
+    #          path: /apps/endpoint
     container:
       image: 'sktcloud/appserving-worker:latest'
       env:
@@ -124,17 +140,16 @@ spec:
       - /bin/sh
       - '-exc'
       - |
-        mkdir -p /apps/app_root
+        mkdir -p /apps/
 
         # fetch manifests from git
         cd /apps
         git clone https://github.com/openinfradev/app-serve-template.git
 
-        cp -r ./app-serve-template/* ./app_root/
-        ls -l ./app_root/
+        cp -r ./app-serve-template/* .
+        ls -l .
 
         # Build manifest using kustomize
-        cd ./app_root
         kustomize build overlays/{{workflow.parameters.resource_spec}} > manifest.yaml
 
         # replace variable for the app
@@ -149,9 +164,9 @@ spec:
         cat manifest.yaml
 
         # Prepare kubeconfig
-        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster}} {{workflow.parameters.target_cluster}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
-          echo "Couldn't get kubeconfig for cluster {{workflow.parameters.cluster_id}}"
+          echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster}}"
           exit 1
         fi
 
@@ -175,4 +190,4 @@ spec:
 
         # For demo purpose only
         echo "Fetching app endpoint..."
-        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
+        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /apps/endpoint

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -6,6 +6,10 @@ metadata:
 spec:
   entrypoint: main
   onExit: exit-handler
+  volumes:
+  - name: tks-proto-vol
+    configMap:
+      name: tks-proto
   arguments:
     parameters:
     # Param "task_type"
@@ -16,6 +20,8 @@ spec:
       value: "C011b88fa"
     - name: app_name
       value: "sample-petclinic"
+    - name: app_id
+      value: ""
     - name: artifact_url
       value: "http://github.com/robertchoi80/sample-petclinic/spring-petclinic-2.7.0-SNAPSHOT.jar"
     - name: image_url
@@ -45,8 +51,8 @@ spec:
 # This expression syntax doesn't work at all as mentioned in the doc as always. Go to hell!
 #    - - name: notify-failure
 #        templateRef:
-#          name: update-asa-status
-#          template: updateAsaStatus
+#          name: update-tks-asa-status
+#          template: updateTksAsaStatus
 #        arguments:
 #          parameters:
 #          - name: status
@@ -55,22 +61,30 @@ spec:
 #        when: "{{workflow.status}} != Succeeded"
     - - name: notify-build-failure
         templateRef:
-          name: update-asa-status
-          template: updateAsaStatus
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
         arguments:
           parameters:
+          - name: asa_id
+            value: "{{workflow.parameters.app_id}}"
           - name: status
             value: "BUILD_FAILED"
-        when: "{{workflow.status}} != Succeeded && {{steps.parse-failed-step.outputs.parameters.step_name}} == build-image"
+          - name: output
+            value: "{{workflow.outputs.parameters.build_output_global}}"
+        when: "{{workflow.status}} != Succeeded && '{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'build-image'"
     - - name: notify-deploy-failure
         templateRef:
-          name: update-asa-status
-          template: updateAsaStatus
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
         arguments:
           parameters:
+          - name: asa_id
+            value: "{{workflow.parameters.app_id}}"
           - name: status
             value: "DEPLOY_FAILED"
-        when: "{{workflow.status}} != Succeeded && {{steps.parse-failed-step.outputs.parameters.step_name}} == deploy-app"
+          - name: output
+            value: "{{workflow.outputs.parameters.deploy_output_global}}"
+        when: "{{workflow.status}} != Succeeded && '{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'deploy-app'"
 
   - name: main
     steps:
@@ -79,23 +93,41 @@ spec:
         template: build-image
     - - name: notify-build-success
         templateRef:
-          name: update-asa-status
-          template: updateAsaStatus
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
         arguments:
           parameters:
+          - name: asa_id
+            value: "{{workflow.parameters.app_id}}"
           - name: status
             value: "BUILD_SUCCESS"
+          - name: output
+            value: "{{steps.build-image.outputs.parameters.build_output}}"
     - - name: deploy-app
         when: "{{workflow.parameters.task_type}} != 'build'"
         template: deploy-app
     - - name: notify-deploy-success
         templateRef:
-          name: update-asa-status
-          template: updateAsaStatus
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
         arguments:
           parameters:
+          - name: asa_id
+            value: "{{workflow.parameters.app_id}}"
           - name: status
             value: "DEPLOY_SUCCESS"
+          - name: output
+            value: "{{steps.deploy-app.outputs.parameters.deploy_output}}"
+    - - name: update-endpoint-url
+        templateRef:
+          name: update-tks-asa-endpoint
+          template: updateTksAsaEndpoint
+        arguments:
+          parameters:
+          - name: asa_id
+            value: "{{workflow.parameters.app_id}}"
+          - name: endpoint
+            value: "{{steps.deploy-app.outputs.parameters.endpoint}}"
 
   #######################
   # Template Definition #
@@ -103,6 +135,8 @@ spec:
   - name: build-image
     volumes:
     - name: varrun
+      emptyDir: {}
+    - name: out
       emptyDir: {}
     sidecars:
     - name: dind
@@ -112,12 +146,20 @@ spec:
         name: varrun
       securityContext:
         privileged: true
+    outputs:
+      parameters:
+      - name: build_output
+        valueFrom:
+          path: /mnt/out/build_output.txt
+        globalName: build_output_global
     container:
       #TODO: split worker image
       image: 'sktcloud/appserving-worker:latest'
       volumeMounts:
-      - mountPath: /var/run
-        name: varrun
+      - name: varrun
+        mountPath: /var/run
+      - name: out
+        mountPath: /mnt/out
       env:
       - name: DOCKERHUB_TOKEN
         valueFrom:
@@ -129,6 +171,8 @@ spec:
       - '-exc'
       - |
         mkdir -p /apps && cd /apps/
+
+        echo "Fetching app artifact.." | tee -a /mnt/out/build_output.txt
 
         # TODO: How to pass auth info here?
         curl -L -o {{workflow.parameters.app_name}}.jar {{workflow.parameters.artifact_url}}
@@ -143,13 +187,20 @@ spec:
         # Build Image #
         ###############
 
+        echo "Composing Dockerfile..." | tee -a /mnt/out/build_output.txt
+
         # Replace port number in Dockerfile
         sed -i "s/JARFILENAME/{{workflow.parameters.app_name}}.jar/g" ./Dockerfile
         sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./Dockerfile
 
         # Debug
-        cat Dockerfile
+        cat Dockerfile | tee -a /mnt/out/build_output.txt
+        echo "=== End of Dockerfile ===" | tee -a /mnt/out/build_output.txt
 
+        # Give time for the docker daemon to start in sidecar
+        sleep 5
+
+        echo "Building container image..." | tee -a /mnt/out/build_output.txt
         # Build docker image
         image_name="{{workflow.parameters.image_url}}"
         docker build -t $image_name .
@@ -158,16 +209,27 @@ spec:
         docker login -u robertchoi80 -p $DOCKERHUB_TOKEN
 
         # Push image
-        docker push $image_name
+        echo "Pushing container image..." | tee -a /mnt/out/build_output.txt
+        docker push $image_name 2>&1
 
   - name: deploy-app
-    #    outputs:
-    #      parameters:
-    #      - name: endpoint_url
-    #        valueFrom:
-    #          path: /apps/endpoint
+    volumes:
+    - name: out
+      emptyDir: {}
+    outputs:
+      parameters:
+      - name: deploy_output
+        valueFrom:
+          path: /mnt/out/deploy_output.txt
+        globalName: deploy_output_global
+      - name: endpoint
+        valueFrom:
+          path: /mnt/out/endpoint
     container:
       image: 'sktcloud/appserving-worker:latest'
+      volumeMounts:
+      - name: out
+        mountPath: /mnt/out
       env:
       - name: DOCKERHUB_TOKEN
         valueFrom:
@@ -188,9 +250,11 @@ spec:
         ls -l .
 
         # Build manifest using kustomize
+        echo "Building kustomize manifest..." | tee -a /mnt/out/deploy_output.txt
         kustomize build overlays/{{workflow.parameters.resource_spec}} > manifest.yaml
 
         # replace variable for the app
+        echo "Replacing variables in the manifest..." | tee -a /mnt/out/deploy_output.txt
         image_name="{{workflow.parameters.image_url}}"
         sed -i "s#EXECUTABLE_PATH#{{workflow.parameters.executable_path}}#g" ./manifest.yaml
         sed -i "s/PORTNUM/{{workflow.parameters.port}}/g" ./manifest.yaml
@@ -202,9 +266,10 @@ spec:
         cat manifest.yaml
 
         # Prepare kubeconfig
+        echo "Preparing kubeconfig for target cluster..." | tee -a /mnt/out/deploy_output.txt
         KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster}} {{workflow.parameters.target_cluster}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
-          echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster}}"
+          echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster}}" | tee -a /mnt/out/deploy_output.txt
           exit 1
         fi
 
@@ -212,23 +277,23 @@ spec:
         export KUBECONFIG='/etc/kubeconfig_temp'
 
         # Deploy
-        kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}}
+        echo "Starting deployment..." | tee -a /mnt/out/deploy_output.txt
+        kubectl apply -f ./manifest.yaml -n {{workflow.parameters.app_name}} | tee -a /mnt/out/deploy_output.txt
 
         # Wait for pod to be ready
-        kubectl wait --for=condition=Available --timeout=300s -n {{workflow.parameters.app_name}} deploy/{{workflow.parameters.app_name}}
+        echo "Waiting for the deployment to be finished..." | tee -a /mnt/out/deploy_output.txt
+        kubectl wait --for=condition=Available --timeout=300s -n {{workflow.parameters.app_name}} deploy/{{workflow.parameters.app_name}} | tee -a /mnt/out/deploy_output.txt
 
         # Temporary output until app-serving service is implemented
         # This msg will be sent to CLI by app-serviing service.
-        echo "The app <{{workflow.parameters.app_name}}> has been deployed successfully. Check the app endpoint as follows.
+        echo "The app <{{workflow.parameters.app_name}}> has been deployed."
 
-        # Endpoint
-        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'
-        # Port number
-        $ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.spec.ports[0].port}'"
+        # Get port number
+        #$ kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.spec.ports[0].port}'"
 
-        # For demo purpose only
-        echo "Fetching app endpoint..."
-        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /apps/endpoint
+        # Writing endpoint to file
+        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.app_name}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /mnt/out/endpoint
+        echo ":{{workflow.parameters.port}}" >> /mnt/out/endpoint
 
   - name: parse-failed-step
     volumes:

--- a/tks_info/update-asa-endpoint-wftpl.yaml
+++ b/tks_info/update-asa-endpoint-wftpl.yaml
@@ -2,10 +2,10 @@ apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
   # what about UpdateApp? 
-  name: update-tks-asa-status
+  name: update-tks-asa-endpoint
   namespace: argo
 spec:
-  entrypoint: updateTksAsaStatus
+  entrypoint: updateTksAsaEndpoint
   arguments:
     parameters:
     - name: tks_info_host
@@ -15,12 +15,11 @@ spec:
     configMap:
       name: tks-proto
   templates:
-  - name: updateTksAsaStatus
+  - name: updateTksAsaEndpoint
     inputs:
       parameters:
       - name: asa_id
-      - name: status
-      - name: output
+      - name: endpoint
     script:
       image: sktdev/python-centos-wf-worker:v1.0
       command: ["python"]
@@ -43,13 +42,11 @@ spec:
         ip = "{{workflow.parameters.tks_info_host}}"
         port = 9110 # if not specified
         addr = "%s:%d" % (ip, port)
-        print("tks-info addr: %s" % addr)
 
-        print("output:\n")
-        print('''{{inputs.parameters.output}}''')
+        print("Updating endpoint for AppServeApp with ID '%s'" % "{{inputs.parameters.asa_id}}")
 
         with grpc.insecure_channel(addr) as channel:
             asa_stub = info_pb2_grpc.AppServeAppServiceStub(channel)
 
-            res = asa_stub.UpdateAppServeAppStatus(info_pb2.UpdateAppServeAppStatusRequest(app_serve_app_id="{{inputs.parameters.asa_id}}", status="{{inputs.parameters.status}}", output='''{{inputs.parameters.output}}'''))
-            print("Response code from UpdateAppServeApp: %d" % res.code)
+            res = asa_stub.UpdateAppServeAppEndpoint(info_pb2.UpdateAppServeAppEndpointRequest(app_serve_app_id="{{inputs.parameters.asa_id}}", endpoint="{{inputs.parameters.endpoint}}"))
+            print("Response code from UpdateAppServeAppEndpoint: %d" % res.code)

--- a/tks_info/update-asa-status-wftpl.yaml
+++ b/tks_info/update-asa-status-wftpl.yaml
@@ -18,8 +18,8 @@ spec:
   - name: updateTksAsaStatus
     inputs:
       parameters:
-			- name: app_serve_app_id
-			- name: status
+      - name: app_serve_app_id
+      - name: status
     script:
       image: sktdev/python-centos-wf-worker:v1.0
       command: ["python"]

--- a/tks_info/update-asa-status-wftpl.yaml
+++ b/tks_info/update-asa-status-wftpl.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  # what about UpdateApp? 
+  name: update-tks-asa-status
+  namespace: argo
+spec:
+  entrypoint: updateTksAsaStatus
+  arguments:
+    parameters:
+    - name: tks_info_host
+      value: "127.0.0.1"
+  volumes:
+  - name: tks-proto-vol
+    configMap:
+      name: tks-proto
+  templates:
+  - name: updateTksAsaStatus
+    inputs:
+      parameters:
+			- name: app_serve_app_id
+			- name: status
+    script:
+      image: sktdev/python-centos-wf-worker:v1.0
+      command: ["python"]
+      env:
+      - name: PYTHONPATH
+        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
+      volumeMounts:
+      - name: tks-proto-vol
+        mountPath: "/opt/protobuf"
+        readOnly: true
+      source: |
+        import sys
+        import google.protobuf
+        import grpc
+        import info_pb2
+        import info_pb2_grpc
+        import common_pb2
+        import common_pb2_grpc
+
+        ip = "{{workflow.parameters.tks_info_host}}"
+        port = 9110 # if not specified
+        addr = "%s:%d" % (ip, port)
+        print("tks-info addr: %s" % addr)
+
+        with grpc.insecure_channel(addr) as channel:
+            asa_stub = info_pb2_grpc.AppServeAppServiceStub(channel)
+
+            res = asa_stub.UpdateAppServeAppStatus(info_pb2.UpdateAppServeAppStatusRequest(app_serve_app_id="{{inputs.parameters.app_serve_app_id}}", status="{{inputs.parameters.status}}"))
+            print("Response code from UpdateAppServeApp: %d" % res.code)


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/349

전에 단독으로 실행하던 workflow를, App-serving LCM에서 호출해서 사용 가능하도록 내용 수정하고, 
이 과정에서 전에 빠져있던 각 단계별 DB 상태 업데이트 및 작업로그 DB 업데이트 로직도 추가하였습니다.
추가적으로, 중간에 실패할 경우에도 상태 업데이트가 되도록 exit-handler 도 추가했습니다.

아래 두 PR이 먼저 머지되어야 합니다.
- https://github.com/openinfradev/tks-proto/pull/37
- https://github.com/openinfradev/tks-info/pull/45

(update) 본 PR 대신 후속 티켓 내용까지 포함한 https://github.com/openinfradev/tks-flow/pull/112 을 바로 리뷰해주시는게 좋을 것 같습니다.