### PR TITLE
Cluster template 지원 및 contract/cluster Git 저장소에 META 정보 추가

### DIFF
--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -35,6 +35,10 @@ spec:
 
         git clone https://$(echo -n $TOKEN)@github.com/${USERNAME}/${CONTRACT_ID}.git
 
+        cd ${CONTRACT_ID}
+        CONTRACT_COMMIT_ID=$(git rev-parse HEAD)
+        cd ..
+
         # Get cluster-api infra provider in the template
         INFRA_PROVIDER="$(cat ${CONTRACT_ID}/$TEMPLATE_NAME/tks-cluster/kustomization.yaml | grep /infra/ | awk -F \/ '{print $3}')"
         echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
@@ -79,6 +83,7 @@ spec:
         esac
 
         echo "Contract ID: "${CONTRACT_ID} > ${CLUSTER_ID}/META
+        echo "Contract Repo Commit: "${CONTRACT_COMMIT_ID} >> ${CLUSTER_ID}/META
         echo "Template Name: "${TEMPLATE_NAME} >> ${CLUSTER_ID}/META
 
         git config --global user.email "taco_support@sk.com"

--- a/github_repo/create-cluster-repo.yaml
+++ b/github_repo/create-cluster-repo.yaml
@@ -12,8 +12,6 @@ spec:
     - name: cluster_id
       value: "cluster_uuid"
     - name: template_name
-      value: "template-std"
-    - name: test_template_name
       value: "aws-reference"
 
   templates:
@@ -123,7 +121,7 @@ spec:
       - name: CLUSTER_ID
         value: "{{workflow.parameters.cluster_id}}"
       - name: TEMPLATE_NAME
-        value: "{{workflow.parameters.test_template_name}}"
+        value: "{{workflow.parameters.template_name}}"
       - name: CLUSTER_INFO
         value: "{{inputs.parameters.cluster_info}}"
       volumeMounts:

--- a/github_repo/create-contract-repo.yaml
+++ b/github_repo/create-contract-repo.yaml
@@ -37,6 +37,8 @@ spec:
         git clone -b ${REVISION} https://github.com/openinfradev/decapod-site
 
         cd decapod-site
+        echo "Decapod Site Repo Revision: "${REVISION} > META
+        echo "Decapod Site Repo Commit: "$(git rev-parse HEAD) >> META
 
         mv .github _github
 

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -14,8 +14,6 @@ spec:
     - name: site_name
       value: "{{ workflow.parameters.cluster_id }}"
     - name: template_name
-      value: "template-std"
-    - name: test_template_name
       value: "aws-reference"
     - name: git_account
       value: "tks-management"


### PR DESCRIPTION
1. 클러스터 생성 워크플로우 호출 시 입력 받은 템플릿 파라미터를 (최초 의도대로) 사용하도록 하였습니다.
2. contract / cluster Git 저장소 생성 할때 META 파일에 원본 Git 저장소 (decapod-site/contract repo) 의 커밋 아이디 등을 남기도록 하였습니다.