### PR TITLE
tests: seperate e2e test sites into aws and aws-msa

### DIFF
--- a/tests/tks-e2e-aws-msa.yaml
+++ b/tests/tks-e2e-aws-msa.yaml
@@ -1,0 +1,198 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-e2e-test-aws-msa
+  namespace: argo
+spec:
+  entrypoint: main
+  onExit: notify-slack
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-tks-client-conf
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: template_name
+            value: "aws-msa-reference"
+    - - name: call-validate-cluster
+        templateRef:
+          name: tks-validate-usercluster
+          template: run-sonobuoy
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: sonobuoy_mode
+            value: "quick"
+    - - name: call-create-service-for-LMA-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-validate-lma-1st
+        templateRef:
+          name: tks-validate-service
+          template: validate-lma
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-create-service-for-SERVICEMESH-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "SERVICE_MESH"
+    - - name: call-validate-servicemesh-1st
+        templateRef:
+          name: tks-validate-service
+          template: validate-servicemesh
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-delete-service-for-SERVICEMESH-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "SERVICE_MESH"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-SERVICEMESH-1st.outputs.parameters.svc_id}}"
+    - - name: call-delete-service-for-LMA-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-LMA-1st.outputs.parameters.svc_id}}"
+    - - name: call-create-service-for-LMA-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-validate-lma-2nd
+        templateRef:
+          name: tks-validate-service
+          template: validate-lma
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-create-service-for-SERVICEMESH-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "SERVICE_MESH"
+    - - name: call-validate-servicemesh-2nd
+        templateRef:
+          name: tks-validate-service
+          template: validate-servicemesh
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-delete-service-for-SERVICEMESH-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "SERVICE_MESH"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-SERVICEMESH-2nd.outputs.parameters.svc_id}}"
+    - - name: call-delete-service-for-LMA-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-LMA-2nd.outputs.parameters.svc_id}}"
+    - - name: call-delete-usercluster
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    # TODO: cleaup remaining AWS resources
+
+  - name: notify-slack
+    steps:
+    - - name: notify-slack
+        templateRef:
+          name: tks-e2e-test-common
+          template: notify-slack

--- a/tests/tks-e2e-aws.yaml
+++ b/tests/tks-e2e-aws.yaml
@@ -1,0 +1,130 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-e2e-test-aws
+  namespace: argo
+spec:
+  entrypoint: main
+  onExit: notify-slack
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-tks-client-conf
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: template_name
+            value: "aws-reference"
+    - - name: call-validate-cluster
+        templateRef:
+          name: tks-validate-usercluster
+          template: run-sonobuoy
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: sonobuoy_mode
+            value: "quick"
+    - - name: call-create-service-for-LMA-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-validate-lma-1st
+        templateRef:
+          name: tks-validate-service
+          template: validate-lma
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-delete-service-for-LMA-1st
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-LMA-1st.outputs.parameters.svc_id}}"
+    - - name: call-create-service-for-LMA-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-validate-lma-2nd
+        templateRef:
+          name: tks-validate-service
+          template: validate-lma
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    - - name: call-delete-service-for-LMA-2nd
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-create-service-for-LMA-2nd.outputs.parameters.svc_id}}"
+    - - name: call-delete-usercluster
+        templateRef:
+          name: tks-e2e-test-common
+          template: delete-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+    # TODO: cleaup remaining AWS resources
+
+  - name: notify-slack
+    steps:
+    - - name: notify-slack
+        templateRef:
+          name: tks-e2e-test-common
+          template: notify-slack

--- a/tests/tks-e2e-common.yaml
+++ b/tests/tks-e2e-common.yaml
@@ -1,11 +1,9 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: tks-e2e-test
+  name: tks-e2e-test-common
   namespace: argo
 spec:
-  entrypoint: main
-  onExit: notify-slack
   arguments:
     parameters:
     - name: tks_info_url
@@ -16,164 +14,10 @@ spec:
       value: "tks-cluster_lcm.tks.com:9110"
 
   templates:
-  - name: main
-    steps:
-    - - name: call-create-tks-client-conf
-        template: create-tks-client-conf
-    - - name: call-create-usercluster
-        template: create-usercluster
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-    - - name: call-validate-cluster
-        templateRef:
-          name: tks-validate-usercluster
-          template: run-sonobuoy
-        arguments:
-          parameters:
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: sonobuoy_mode
-            value: "quick"
-    - - name: call-create-service-for-LMA-1st
-        template: create-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "LMA"
-    - - name: call-validate-lma-1st
-        templateRef:
-          name: tks-validate-service
-          template: validate-lma
-        arguments:
-          parameters:
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-    - - name: call-create-service-for-SERVICEMESH-1st
-        template: create-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "SERVICE_MESH"
-    - - name: call-validate-servicemesh-1st
-        templateRef:
-          name: tks-validate-service
-          template: validate-servicemesh
-        arguments:
-          parameters:
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-    - - name: call-delete-service-for-SERVICEMESH-1st
-        template: delete-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "SERVICE_MESH"
-          - name: svc_id
-            value: "{{steps.call-create-service-for-SERVICEMESH-1st.outputs.parameters.svc_id}}"
-    - - name: call-delete-service-for-LMA-1st
-        template: delete-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "LMA"
-          - name: svc_id
-            value: "{{steps.call-create-service-for-LMA-1st.outputs.parameters.svc_id}}"
-    - - name: call-create-service-for-LMA-2nd
-        template: create-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "LMA"
-    - - name: call-validate-lma-2nd
-        templateRef:
-          name: tks-validate-service
-          template: validate-lma
-        arguments:
-          parameters:
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-    - - name: call-create-service-for-SERVICEMESH-2nd
-        template: create-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "SERVICE_MESH"
-    - - name: call-validate-servicemesh-2nd
-        templateRef:
-          name: tks-validate-service
-          template: validate-servicemesh
-        arguments:
-          parameters:
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-    - - name: call-delete-service-for-SERVICEMESH-2nd
-        template: delete-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "SERVICE_MESH"
-          - name: svc_id
-            value: "{{steps.call-create-service-for-SERVICEMESH-2nd.outputs.parameters.svc_id}}"
-    - - name: call-delete-service-for-LMA-2nd
-        template: delete-service
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-          - name: service_name
-            value: "LMA"
-          - name: svc_id
-            value: "{{steps.call-create-service-for-LMA-2nd.outputs.parameters.svc_id}}"
-    - - name: call-delete-usercluster
-        template: delete-usercluster
-        arguments:
-          parameters:
-          - name: tks_client_conf
-            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
-          - name: cluster_id
-            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
-    # TODO: cleaup remaining AWS resources
-
-  #######################
-  # Template Definition #
-  #######################
-
   - name: create-tks-client-conf
     container:
       name: create-tks-client-conf
-      image: 'sktcloud/tks-e2e-test:v2.0.0'
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
       command:
         - /bin/bash
         - '-exc'
@@ -204,9 +48,10 @@ spec:
     inputs:
       parameters:
       - name: tks_client_conf
+      - name: template_name
     container:
       name: create-usercluster
-      image: 'sktcloud/tks-e2e-test:v2.0.0'
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
       command:
         - /bin/bash
         - '-exc'
@@ -215,7 +60,7 @@ spec:
 
           CL_NAME="e2e-test-$(date "+%Y-%m%d-%H%M")"
           echo "* Create $CL_NAME cluster"
-          tks cluster create ${CL_NAME}
+          tks cluster create ${CL_NAME} --template "{{inputs.parameters.template_name}}"
 
           threshold=30
           for i in $(seq 1 $threshold)
@@ -255,7 +100,7 @@ spec:
       - name: cluster_id
     container:
       name: delete-usercluster
-      image: 'sktcloud/tks-e2e-test:v2.0.0'
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
       command:
         - /bin/bash
         - '-exc'
@@ -294,7 +139,7 @@ spec:
       - name: service_name
     container:
       name: create-service
-      image: 'sktcloud/tks-e2e-test:v2.0.0'
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
       command:
         - /bin/bash
         - '-exc'
@@ -343,7 +188,7 @@ spec:
       - name: svc_id
     container:
       name: create-service
-      image: 'sktcloud/tks-e2e-test:v2.0.0'
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
       command:
         - /bin/bash
         - '-exc'


### PR DESCRIPTION
E2E 테스트를 위한 워크플로우 템플릿을 aws-reference, aws-msa-reference 2개의 사이트를 위해 분리하였습니다.
실제로 실행되는 템플릿 정의는 common 워크플로우 템플릿에 두고 각각의 e2e 워크플로우에서 호출하는 형태로 수정하였습니다.