### PR TITLE
tks stack 워크플로우 템플릿 추가

### DIFF
--- a/tests/tks-e2e-aws-msa.yaml
+++ b/tests/tks-e2e-aws-msa.yaml
@@ -20,16 +20,26 @@ spec:
     steps:
     - - name: call-create-tks-client-conf
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-tks-client-conf
-    - - name: call-create-usercluster
+    - - name: call-get-cluster-name
         templateRef:
           name: tks-e2e-test-common
+          template: get-cluster-name
+        arguments:
+          parameters:
+          - name: postfix
+            value: "aws-msa"
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-cli
           template: create-usercluster
         arguments:
           parameters:
           - name: tks_client_conf
             value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_name
+            value: "{{steps.call-get-cluster-name.outputs.parameters.cluster-name}}"
           - name: template_name
             value: "aws-msa-reference"
     - - name: call-validate-cluster
@@ -44,7 +54,7 @@ spec:
             value: "quick"
     - - name: call-create-service-for-LMA-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -64,7 +74,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-create-service-for-SERVICEMESH-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -84,7 +94,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-delete-service-for-SERVICEMESH-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -98,7 +108,7 @@ spec:
             value: "{{steps.call-create-service-for-SERVICEMESH-1st.outputs.parameters.svc_id}}"
     - - name: call-delete-service-for-LMA-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -112,7 +122,7 @@ spec:
             value: "{{steps.call-create-service-for-LMA-1st.outputs.parameters.svc_id}}"
     - - name: call-create-service-for-LMA-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -132,7 +142,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-create-service-for-SERVICEMESH-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -152,7 +162,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-delete-service-for-SERVICEMESH-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -166,7 +176,7 @@ spec:
             value: "{{steps.call-create-service-for-SERVICEMESH-2nd.outputs.parameters.svc_id}}"
     - - name: call-delete-service-for-LMA-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -180,7 +190,7 @@ spec:
             value: "{{steps.call-create-service-for-LMA-2nd.outputs.parameters.svc_id}}"
     - - name: call-delete-usercluster
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-usercluster
         arguments:
           parameters:

--- a/tests/tks-e2e-aws.yaml
+++ b/tests/tks-e2e-aws.yaml
@@ -20,16 +20,26 @@ spec:
     steps:
     - - name: call-create-tks-client-conf
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-tks-client-conf
-    - - name: call-create-usercluster
+    - - name: call-get-cluster-name
         templateRef:
           name: tks-e2e-test-common
+          template: get-cluster-name
+        arguments:
+          parameters:
+          - name: postfix
+            value: "aws"
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-cli
           template: create-usercluster
         arguments:
           parameters:
           - name: tks_client_conf
             value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_name
+            value: "{{steps.call-get-cluster-name.outputs.parameters.cluster-name}}"
           - name: template_name
             value: "aws-reference"
     - - name: call-validate-cluster
@@ -44,7 +54,7 @@ spec:
             value: "quick"
     - - name: call-create-service-for-LMA-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -64,7 +74,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-delete-service-for-LMA-1st
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -78,7 +88,7 @@ spec:
             value: "{{steps.call-create-service-for-LMA-1st.outputs.parameters.svc_id}}"
     - - name: call-create-service-for-LMA-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: create-service
         arguments:
           parameters:
@@ -98,7 +108,7 @@ spec:
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
     - - name: call-delete-service-for-LMA-2nd
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-service
         arguments:
           parameters:
@@ -112,7 +122,7 @@ spec:
             value: "{{steps.call-create-service-for-LMA-2nd.outputs.parameters.svc_id}}"
     - - name: call-delete-usercluster
         templateRef:
-          name: tks-e2e-test-common
+          name: tks-cli
           template: delete-usercluster
         arguments:
           parameters:

--- a/tests/tks-e2e-common.yaml
+++ b/tests/tks-e2e-common.yaml
@@ -14,23 +14,19 @@ spec:
       value: "tks-cluster_lcm.tks.com:9110"
 
   templates:
-  - name: create-tks-client-conf
+  - name: get-cluster-name
+    inputs:
+      parameters:
+      - name: postfix
     container:
-      name: create-tks-client-conf
-      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      image: centos:centos7
       command:
         - /bin/bash
         - '-exc'
         - |
-          cat > /mnt/out/tks-client.yaml <<EOF
-          tksInfoUrl: "{{workflow.parameters.tks_info_url}}"
-          tksContractUrl: "{{workflow.parameters.tks_contract_url}}"
-          tksClusterLcmUrl: "{{workflow.parameters.tks_cluster_lcm_url}}"
-          EOF
+          CL_NAME="e2e-test-{{inputs.parameters.postfix}}-$(date "+%Y-%m%d-%H%M")"
 
-          cat /mnt/out/tks-client.yaml
-
-          tks --config /mnt/out/tks-client.yaml cluster list
+          echo $CL_NAME | tee /mnt/out/cluster_name.txt
       volumeMounts:
         - name: out
           mountPath: /mnt/out
@@ -39,185 +35,10 @@ spec:
         emptyDir: { }
     outputs:
       parameters:
-      - name: tks_client_conf
+      - name: cluster-name
         valueFrom:
           default: "Something wrong"
-          path: /mnt/out/tks-client.yaml
-
-  - name: create-usercluster
-    inputs:
-      parameters:
-      - name: tks_client_conf
-      - name: template_name
-    container:
-      name: create-usercluster
-      image: 'sktcloud/tks-e2e-test:v2.0.1'
-      command:
-        - /bin/bash
-        - '-exc'
-        - |
-          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
-
-          CL_NAME="e2e-test-$(date "+%Y-%m%d-%H%M")"
-          echo "* Create $CL_NAME cluster"
-          tks cluster create ${CL_NAME} --template "{{inputs.parameters.template_name}}"
-
-          threshold=30
-          for i in $(seq 1 $threshold)
-          do
-            CL_STATUS=$(tks cluster list  | grep $CL_NAME | awk '{ print $3 }')
-            if [ "$CL_STATUS" = "RUNNING" ]; then
-              break
-            elif [ "$CL_STATUS" = "ERROR" ]; then
-              exit 1
-            fi
-
-            if [ "$i" -ge "$threshold" ]; then
-              echo "Timed out waiting for user-cluster to be ready."
-              exit 1
-            fi
-            sleep 1m
-          done
-
-          tks cluster list | grep $CL_NAME | awk '{print $2}' | tee /mnt/out/cluster_id.txt
-      volumeMounts:
-        - name: out
-          mountPath: /mnt/out
-    volumes:
-      - name: out
-        emptyDir: { }
-    outputs:
-      parameters:
-      - name: cluster-id
-        valueFrom:
-          default: "Something wrong"
-          path: /mnt/out/cluster_id.txt
-
-  - name: delete-usercluster
-    inputs:
-      parameters:
-      - name: tks_client_conf
-      - name: cluster_id
-    container:
-      name: delete-usercluster
-      image: 'sktcloud/tks-e2e-test:v2.0.1'
-      command:
-        - /bin/bash
-        - '-exc'
-        - |
-          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
-
-          tks cluster delete {{inputs.parameters.cluster_id}}
-
-          threshold=30
-          for i in $(seq 1 $threshold)
-          do
-            CL_EXIST=$(tks cluster list | grep {{inputs.parameters.cluster_id}} | wc -l)
-            if [ "$CL_EXIST" = "0" ]; then
-              break
-            fi
-
-            CL_STATUS=$(tks cluster list  | grep {{inputs.parameters.cluster_id}} | awk '{ print $3 }')
-            if [ "$CL_STATUS" = "DELETED" ]; then
-              break
-            elif [ "$CL_STATUS" = "ERROR" ]; then
-              exit 1
-            fi
-
-            if [ "$i" -ge "$threshold" ]; then
-              echo "Timed out waiting for user-cluster to be deleted."
-              exit 1
-            fi
-            sleep 1m
-          done
-
-  - name: create-service
-    inputs:
-      parameters:
-      - name: tks_client_conf
-      - name: cluster_id
-      - name: service_name
-    container:
-      name: create-service
-      image: 'sktcloud/tks-e2e-test:v2.0.1'
-      command:
-        - /bin/bash
-        - '-exc'
-        - |
-          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
-
-          tks service create --cluster-id {{inputs.parameters.cluster_id}} --service-name {{inputs.parameters.service_name}}
-
-          threshold=30
-          for i in $(seq 1 $threshold)
-          do
-            SVC_STATUS=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $3}')
-            if [ "$SVC_STATUS" = "APP_GROUP_RUNNING" ]; then
-              break
-            elif [ "$SVC_STATUS" = "APP_GROUP_ERROR" ]; then
-              exit 1
-            fi
-
-            if [ "$i" -ge "$threshold" ]; then
-              echo "Timed out waiting for {{inputs.parameters.service_name}} to be ready."
-              exit 1
-            fi
-            sleep 1m
-          done
-
-          echo $(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $2}') | tee /mnt/out/svc_id.txt
-      volumeMounts:
-        - name: out
-          mountPath: /mnt/out
-    volumes:
-      - name: out
-        emptyDir: { }
-    outputs:
-      parameters:
-      - name: svc_id
-        valueFrom:
-          default: "Something wrong"
-          path: /mnt/out/svc_id.txt
-
-  - name: delete-service
-    inputs:
-      parameters:
-      - name: tks_client_conf
-      - name: cluster_id
-      - name: service_name
-      - name: svc_id
-    container:
-      name: create-service
-      image: 'sktcloud/tks-e2e-test:v2.0.1'
-      command:
-        - /bin/bash
-        - '-exc'
-        - |
-          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
-
-          tks service delete {{inputs.parameters.svc_id}}
-
-          threshold=30
-          for i in $(seq 1 $threshold)
-          do
-            SVC_EXIST=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.svc_id}} | wc -l)
-            if [ "$SVC_EXIST" = "0" ]; then
-              break
-            fi
-
-            SVC_STATUS=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $3}')
-            if [ "$SVC_STATUS" = "APP_GROUP_DELETED" ]; then
-              break
-            elif [ "$SVC_STATUS" = "APP_GROUP_ERROR" ]; then
-              exit 1
-            fi
-
-            if [ "$i" -ge "$threshold" ]; then
-              echo "Timed out waiting for {{inputs.parameters.service_name}} to be deleted."
-              exit 1
-            fi
-            sleep 1m
-          done
+          path: /mnt/out/cluster_name.txt
 
   - name: notify-slack
     container:

--- a/tks-cli/tks-cli.yaml
+++ b/tks-cli/tks-cli.yaml
@@ -1,0 +1,250 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-cli
+  namespace: argo
+spec:
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+
+  templates:
+  - name: create-tks-client-conf
+    container:
+      name: create-tks-client-conf
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          cat > /mnt/out/tks-client.yaml <<EOF
+          tksInfoUrl: "{{workflow.parameters.tks_info_url}}"
+          tksContractUrl: "{{workflow.parameters.tks_contract_url}}"
+          tksClusterLcmUrl: "{{workflow.parameters.tks_cluster_lcm_url}}"
+          EOF
+
+          cat /mnt/out/tks-client.yaml
+
+          tks --config /mnt/out/tks-client.yaml cluster list
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: tks_client_conf
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/tks-client.yaml
+
+  - name: create-usercluster
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: cluster_name
+      - name: template_name
+    container:
+      name: create-usercluster
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          CL_NAME="{{inputs.parameters.cluster_name}}"
+          echo "* Create $CL_NAME cluster"
+          tks cluster create ${CL_NAME} --template "{{inputs.parameters.template_name}}"
+
+          threshold=30
+          for i in $(seq 1 $threshold)
+          do
+            CL_STATUS=$(tks cluster list  | grep $CL_NAME | awk '{ print $3 }')
+            if [ "$CL_STATUS" = "RUNNING" ]; then
+              break
+            elif [ "$CL_STATUS" = "ERROR" ]; then
+              exit 1
+            fi
+
+            if [ "$i" -ge "$threshold" ]; then
+              echo "Timed out waiting for user-cluster to be ready."
+              exit 1
+            fi
+            sleep 1m
+          done
+
+          tks cluster list | grep $CL_NAME | awk '{print $2}' | tee /mnt/out/cluster_id.txt
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: cluster-id
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/cluster_id.txt
+
+  - name: delete-usercluster
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: cluster_id
+    container:
+      name: delete-usercluster
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          tks cluster delete {{inputs.parameters.cluster_id}}
+
+          threshold=30
+          for i in $(seq 1 $threshold)
+          do
+            CL_EXIST=$(tks cluster list | grep {{inputs.parameters.cluster_id}} | wc -l)
+            if [ "$CL_EXIST" = "0" ]; then
+              break
+            fi
+
+            CL_STATUS=$(tks cluster list  | grep {{inputs.parameters.cluster_id}} | awk '{ print $3 }')
+            if [ "$CL_STATUS" = "DELETED" ]; then
+              break
+            elif [ "$CL_STATUS" = "ERROR" ]; then
+              exit 1
+            fi
+
+            if [ "$i" -ge "$threshold" ]; then
+              echo "Timed out waiting for user-cluster to be deleted."
+              exit 1
+            fi
+            sleep 1m
+          done
+
+  - name: create-service
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: cluster_id
+      - name: service_name
+    container:
+      name: create-service
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          tks service create --cluster-id {{inputs.parameters.cluster_id}} --service-name {{inputs.parameters.service_name}}
+
+          threshold=30
+          for i in $(seq 1 $threshold)
+          do
+            SVC_STATUS=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $3}')
+            if [ "$SVC_STATUS" = "APP_GROUP_RUNNING" ]; then
+              break
+            elif [ "$SVC_STATUS" = "APP_GROUP_ERROR" ]; then
+              exit 1
+            fi
+
+            if [ "$i" -ge "$threshold" ]; then
+              echo "Timed out waiting for {{inputs.parameters.service_name}} to be ready."
+              exit 1
+            fi
+            sleep 1m
+          done
+
+          echo $(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $2}') | tee /mnt/out/svc_id.txt
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: svc_id
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/svc_id.txt
+
+  - name: delete-service
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: cluster_id
+      - name: service_name
+      - name: svc_id
+    container:
+      name: create-service
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          tks service delete {{inputs.parameters.svc_id}}
+
+          threshold=30
+          for i in $(seq 1 $threshold)
+          do
+            SVC_EXIST=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.svc_id}} | wc -l)
+            if [ "$SVC_EXIST" = "0" ]; then
+              break
+            fi
+
+            SVC_STATUS=$(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $3}')
+            if [ "$SVC_STATUS" = "APP_GROUP_DELETED" ]; then
+              break
+            elif [ "$SVC_STATUS" = "APP_GROUP_ERROR" ]; then
+              exit 1
+            fi
+
+            if [ "$i" -ge "$threshold" ]; then
+              echo "Timed out waiting for {{inputs.parameters.service_name}} to be deleted."
+              exit 1
+            fi
+            sleep 1m
+          done
+
+  - name: get-service-id
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: cluster_id
+      - name: service_name
+    container:
+      name: get-service-id
+      image: 'sktcloud/tks-e2e-test:v2.0.1'
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          echo $(tks service list {{inputs.parameters.cluster_id}} | grep {{inputs.parameters.service_name}} | awk '{print $2}') | tee /mnt/out/svc_id.txt
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: svc_id
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/svc_id.txt

--- a/tks-stack/tks-stack-create-aws-msa.yaml
+++ b/tks-stack/tks-stack-create-aws-msa.yaml
@@ -1,0 +1,61 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-stack-create-aws-msa
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+    - name: cluster_name
+      value: "cluster-foo"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-cli
+          template: create-tks-client-conf
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-cli
+          template: create-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_name
+            value: "{{workflow.parameters.cluster_name}}"
+          - name: template_name
+            value: "aws-msa-reference"
+    - - name: call-create-service-for-LMA
+        templateRef:
+          name: tks-cli
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-create-service-for-SERVICEMESH
+        templateRef:
+          name: tks-cli
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "SERVICE_MESH"

--- a/tks-stack/tks-stack-create-aws.yaml
+++ b/tks-stack/tks-stack-create-aws.yaml
@@ -1,0 +1,49 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-stack-create-aws
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+    - name: cluster_name
+      value: "cluster-foo"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-cli
+          template: create-tks-client-conf
+    - - name: call-create-usercluster
+        templateRef:
+          name: tks-cli
+          template: create-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_name
+            value: "{{workflow.parameters.cluster_name}}"
+          - name: template_name
+            value: "aws-reference"
+    - - name: call-create-service-for-LMA
+        templateRef:
+          name: tks-cli
+          template: create-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
+          - name: service_name
+            value: "LMA"

--- a/tks-stack/tks-stack-delete-aws-msa.yaml
+++ b/tks-stack/tks-stack-delete-aws-msa.yaml
@@ -1,0 +1,87 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-stack-delete-aws-msa
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+    - name: cluster_id
+      value: "c011b88fa"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-cli
+          template: create-tks-client-conf
+    - - name: call-get-service-id-of-SERVICEMESH
+        templateRef:
+          name: tks-cli
+          template: get-service-id
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "SERVICE_MESH"
+    - - name: call-delete-service-for-SERVICEMESH-1st
+        templateRef:
+          name: tks-cli
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "SERVICE_MESH"
+          - name: svc_id
+            value: "{{steps.call-get-service-id-of-SERVICEMESH.outputs.parameters.svc_id}}"
+    - - name: call-get-service-id-of-LMA
+        templateRef:
+          name: tks-cli
+          template: get-service-id
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-delete-service-for-LMA
+        templateRef:
+          name: tks-cli
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-get-service-id-of-LMA.outputs.parameters.svc_id}}"
+    - - name: call-delete-usercluster
+        templateRef:
+          name: tks-cli
+          template: delete-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"

--- a/tks-stack/tks-stack-delete-aws.yaml
+++ b/tks-stack/tks-stack-delete-aws.yaml
@@ -1,0 +1,61 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-stack-delete-aws
+  namespace: argo
+spec:
+  entrypoint: main
+  arguments:
+    parameters:
+    - name: tks_info_url
+      value: "tks-info.tks.com:9110"
+    - name: tks_contract_url
+      value: "tks-contract.tks.com:9110"
+    - name: tks_cluster_lcm_url
+      value: "tks-cluster_lcm.tks.com:9110"
+    - name: cluster_id
+      value: "c011b88fa"
+
+  templates:
+  - name: main
+    steps:
+    - - name: call-create-tks-client-conf
+        templateRef:
+          name: tks-cli
+          template: create-tks-client-conf
+    - - name: call-get-service-id-of-LMA
+        templateRef:
+          name: tks-cli
+          template: get-service-id
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "LMA"
+    - - name: call-delete-service-for-LMA
+        templateRef:
+          name: tks-cli
+          template: delete-service
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"
+          - name: service_name
+            value: "LMA"
+          - name: svc_id
+            value: "{{steps.call-get-service-id-of-LMA.outputs.parameters.svc_id}}"
+    - - name: call-delete-usercluster
+        templateRef:
+          name: tks-cli
+          template: delete-usercluster
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: cluster_id
+            value: "{{ workflow.parameters.cluster_id }}"


### PR DESCRIPTION
클러스터와 서비스를 한 번에 설치하기 위한 스택 워크플로우 템플릿을 추가합니다.
- tks-stack-create-aws: cluster, lma
- tks-stack-create-aws-msa: cluster, lma, service-mesh

e2e 테스트 구현을 재사용하였고 e2e 테스트와 tks stack이 공통으로 사용되는 부분은 tks-cli 워크플로우 템플릿으로 분리하였습니다.