### PR TITLE
manifests 리뷰용 PR 생성  / 클러스터 import 후 자동 manifests 생성

### DIFF
--- a/github_repo/render-manifests.yaml
+++ b/github_repo/render-manifests.yaml
@@ -7,8 +7,8 @@ spec:
   entrypoint: main
   arguments:
     parameters:
-    - name: site_name
-      value: decapod-reference
+    - name: cluster_id
+      value: "c011b88fa"
     - name: base_repo_url
       value: 'github.com/openinfradev/decapod-base-yaml'
     - name: base_repo_branch
@@ -21,6 +21,8 @@ spec:
       value: 'github.com/openinfradev/decapod-manifests'
     - name: manifest_repo_branch
       value: main
+    - name: git_repo_type
+      value: github
 
   templates:
   #=========================================================
@@ -32,8 +34,8 @@ spec:
         template: render-manifests-template
         arguments:
           parameters:
-          - name: site_name
-            value: "{{workflow.parameters.site_name}}"
+          - name: cluster_id
+            value: "{{workflow.parameters.cluster_id}}"
           - name: base_repo_url
             value: "{{workflow.parameters.base_repo_url}}"
           - name: base_repo_branch
@@ -46,6 +48,8 @@ spec:
             value: "{{workflow.parameters.manifest_repo_url}}"
           - name: manifest_repo_branch
             value: "{{workflow.parameters.manifest_repo_branch}}"
+          - name: git_repo_type
+            value: "{{workflow.parameters.git_repo_type}}"
 
   #=========================================================
   # Template Definition
@@ -53,16 +57,17 @@ spec:
   - name: render-manifests-template
     inputs:
       parameters:
-      - name: site_name
+      - name: cluster_id
       - name: base_repo_url
       - name: base_repo_branch
       - name: site_repo_url
       - name: site_repo_branch
       - name: manifest_repo_url
       - name: manifest_repo_branch
+      - name: git_repo_type
     container:
       name: render-manifests-template
-      image: sktcloud/decapod-render:v2.0.0
+      image: sktcloud/decapod-render:v2.1.0
       command:
       - /bin/bash
       - '-exc'
@@ -82,31 +87,35 @@ spec:
           fi
         }
 
-        SITE_NAME={{inputs.parameters.site_name}}
+        GIT_TOKEN=${TOKEN//[$'\t\r\n ']}
+
+        CLUSTER_ID={{inputs.parameters.cluster_id}}
         BASE_REPO_URL={{inputs.parameters.base_repo_url}}
         BASE_REPO_BRANCH={{inputs.parameters.base_repo_branch}}
         SITE_REPO_URL={{inputs.parameters.site_repo_url}}
         SITE_REPO_BRANCH={{inputs.parameters.site_repo_branch}}
         MANIFEST_REPO_URL={{inputs.parameters.manifest_repo_url}}
         MANIFEST_REPO_BRANCH={{inputs.parameters.manifest_repo_branch}}
+        GIT_REPO_TYPE={{inputs.parameters.git_repo_type}}
         SITE_DIR="tks-site-yaml"
         BASE_DIR="decapod-base-yaml"
         DOCKER_IMAGE_REPO="docker.io"
         OUTPUT_DIR="output"
 
         # download site-yaml
-        git clone -b ${SITE_REPO_BRANCH} https://$(echo -n ${TOKEN})@${SITE_REPO_URL} ${SITE_DIR}
+        git clone -b ${SITE_REPO_BRANCH} https://$(echo -n ${GIT_TOKEN})@${SITE_REPO_URL} ${SITE_DIR}
         log $? "INFO" "Fetching ${SITE_REPO_URL} with ${SITE_REPO_BRANCH} branch/tag........."
         cd ${SITE_DIR}
-        site_commit_msg=$(git show -s --format="%h %s" HEAD)
+        site_commit_msg=$(git show -s --format="[%h] %s" HEAD)
+        site_commit_id=$(git show -s --format="%h" HEAD)
 
         # extract directory for rendering
         site_list=$(ls -d */ | sed 's/\///g' | egrep -v "docs|^template|^deprecated|output|offline")
 
         # download base-yaml
-        git clone -b ${BASE_REPO_BRANCH} https://$(echo -n ${TOKEN})@${BASE_REPO_URL} ${BASE_DIR}
+        git clone -b ${BASE_REPO_BRANCH} https://$(echo -n ${GIT_TOKEN})@${BASE_REPO_URL} ${BASE_DIR}
         log $? "INFO" "Fetching ${BASE_REPO_URL} with ${BASE_REPO_BRANCH} branch/tag........."
-        base_commit_msg=$(cd ${BASE_DIR}; git show -s --format="%h %s" HEAD)
+        base_commit_msg=$(cd ${BASE_DIR}; git show -s --format="[%h] %s" HEAD)
 
         mkdir -p ${OUTPUT_DIR}
 
@@ -136,7 +145,7 @@ spec:
 
           done
 
-          if [[ ${SITE_NAME} != *"decapod"* ]]; then
+          if [[ ${CLUSTER_ID} != *"decapod"* ]]; then
             log 0 "INFO" "Almost finished: changing namespace for aws-cluster-resouces from argo to cluster-name.."
             sed -i "s/ namespace: argo/ namespace: ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/*
             sed -i "s/- argo/- ${site}/g" $(pwd)/${OUTPUT_DIR}/${site}/tks-cluster/cluster-api-aws/*
@@ -160,9 +169,12 @@ spec:
         #-----------------------------------------------
         # push manifests files
         #-----------------------------------------------
-        git clone https://$(echo -n ${TOKEN})@${MANIFEST_REPO_URL} origin-manifests
+        git clone https://$(echo -n ${GIT_TOKEN})@${MANIFEST_REPO_URL} origin-manifests
         log 0 "INFO" "git clone ${MANIFEST_REPO_URL}"
         cd origin-manifests
+        if [ -z "${MANIFEST_REPO_BRANCH}" ]; then
+                MANIFEST_REPO_BRANCH="decapod-${site_commit_id}"
+        fi
         check_branch=$(git ls-remote --heads origin ${MANIFEST_REPO_BRANCH})
         if [[ -z ${check_branch} ]]; then
           git checkout -b ${MANIFEST_REPO_BRANCH}
@@ -178,8 +190,13 @@ spec:
         git config --global user.email "taco_support@sk.com"
         git config --global user.name "SKTelecom TACO"
         git add -A
-        git commit -m "base_commit_msg: ${base_commit_msg}\n site_commit_msg: ${site_commit_msg}"
+        git commit -m "base: ${base_commit_msg}, site: ${site_commit_msg}"
         git push origin ${MANIFEST_REPO_BRANCH}
+
+        if [ "${MANIFEST_REPO_BRANCH}" != "main" ] && [ "${GIT_REPO_TYPE}" == "gitea" ]; then
+          curl -X POST -H "content-type: application/json" -H "Authorization: token ${GIT_TOKEN}" --data "{ \"base\": \"main\", \"body\": \"rendered from\n - base: ${base_commit_msg}\n - site: ${site_commit_msg}\", \"head\": \"${MANIFEST_REPO_BRANCH}\", \"title\": \"rendered from site: ${site_commit_msg}\"}" https://${MANIFEST_REPO_URL%%/*}/api/v1/repos/${MANIFEST_REPO_URL#*/}/pulls
+        fi
+
         log 0 "INFO" "pushed all manifests files"
 
       envFrom:

--- a/tks-cluster/import-usercluster-wftpl.yaml
+++ b/tks-cluster/import-usercluster-wftpl.yaml
@@ -18,7 +18,9 @@ spec:
     - name: git_base_url
       value: "github.com"
     - name: git_account
-      value: "tks-management"
+      value: "tks"
+    - name: git_org
+      value: "decapod10"
 
   volumes:
   - name: kubeconfig-adm
@@ -44,6 +46,8 @@ spec:
           parameters:
           - name: git_base_url
             value: "{{ workflow.parameters.git_base_url }}"
+          - name: git_org
+            value: "{{ workflow.parameters.git_org }}"
 
     - - name: import-cluster
         template: import-cluster
@@ -53,6 +57,29 @@ spec:
               value: "{{ workflow.parameters.cluster_id }}"
             - name: kubeconfig 
               value: "{{ workflow.parameters.kubeconfig }}"
+
+    - - name: render-manifests
+        templateRef:
+          name: render-manifests
+          template: render-manifests-template
+        arguments:
+          parameters:
+            - name: cluster_id
+              value: "{{ workflow.parameters.cluster_id }}"
+            - name: base_repo_url
+              value: '{{ workflow.parameters.git_base_url }}/{{ workflow.parameters.git_account }}/decapod-base-yaml'
+            - name: base_repo_branch
+              value: main
+            - name: site_repo_url
+              value: '{{ workflow.parameters.git_base_url }}/{{ workflow.parameters.git_org }}/{{ workflow.parameters.cluster_id }}'
+            - name: site_repo_branch
+              value: main
+            - name: manifest_repo_url
+              value: '{{ workflow.parameters.git_base_url }}/{{ workflow.parameters.git_org }}/{{ workflow.parameters.cluster_id }}-manifests'
+            - name: manifest_repo_branch
+              value: main
+            - name: git_repo_type
+              value: gitea
 
     - - name: init-cluster-for-tks
         template: init-cluster-for-tks
@@ -70,6 +97,7 @@ spec:
     inputs:
       parameters:
       - name: git_base_url
+      - name: git_org
     container:
       name: 'createClusterRepo'
       image: ghcr.io/sktelecom/ghcli-alpine:2.0.0
@@ -78,13 +106,14 @@ spec:
       - /bin/bash
       - -ecx
       - |
+        echo ${GIT_ORG}
         TOKEN=$(echo -n $TOKEN)
-        curl -X POST -H "content-type: application/json" -H "Authorization: token ${TOKEN}" --data '{"name": "'${CLUSTER_ID}'"}' https://${GIT_BASE_URL}/api/v1/user/repos
-        curl -X POST -H "content-type: application/json" -H "Authorization: token ${TOKEN}" --data '{"name": "'$CLUSTER_ID'-manifests"}' https://${GIT_BASE_URL}/api/v1/user/repos
+        curl -X POST -H "content-type: application/json" -H "Authorization: token ${TOKEN}" --data '{"name": "'${CLUSTER_ID}'"}' https://${GIT_BASE_URL}/api/v1/orgs/${GIT_ORG}/repos
+        curl -X POST -H "content-type: application/json" -H "Authorization: token ${TOKEN}" --data '{"name": "'$CLUSTER_ID'-manifests"}' https://${GIT_BASE_URL}/api/v1/orgs/${GIT_ORG}/repos
 
-        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${USERNAME}/${CONTRACT_ID}.git
-        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${USERNAME}/${CLUSTER_ID}.git
-        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${USERNAME}/${CLUSTER_ID}-manifests.git
+        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${GIT_ORG}/${CONTRACT_ID}.git
+        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${GIT_ORG}/${CLUSTER_ID}.git
+        git clone https://$(echo -n $TOKEN)@${GIT_BASE_URL}/${GIT_ORG}/${CLUSTER_ID}-manifests.git
 
         cd ${CONTRACT_ID}
         CONTRACT_COMMIT_ID=$(git rev-parse HEAD)
@@ -134,6 +163,8 @@ spec:
         value: "{{workflow.parameters.template_name}}"
       - name: GIT_BASE_URL
         value: "{{inputs.parameters.git_base_url}}"
+      - name: GIT_ORG
+        value: "{{inputs.parameters.git_org}}"
 
   - name: import-cluster
     inputs:


### PR DESCRIPTION
- render-manifests: manifests 생성 후 main 브랜치에 바로 반영하는 대신 PR 생성하는 기능을 추가하였습니다: Git 저장소가 gitea 경우에만 한정되어 동작합니다 (if 'manifest_repo_branch' is empty and 'git_repo_type' is gitea)
- import-cluster: 갱신 된 render-manifests를 호출하여 manifests 생성 및 저장소 반영이 자동으로 이루어지도록 변경하였습니다.