### PR TITLE
add step to tests

### DIFF
--- a/tests/tks-e2e-aws-msa.yaml
+++ b/tests/tks-e2e-aws-msa.yaml
@@ -22,14 +22,28 @@ spec:
         templateRef:
           name: tks-cli
           template: create-tks-client-conf
-    - - name: call-get-cluster-name
+    - - name: call-generate-names
         templateRef:
           name: tks-e2e-test-common
-          template: get-cluster-name
+          template: generate-names
         arguments:
           parameters:
           - name: postfix
-            value: "aws-msa"
+            value: "aws"          
+    - - name: call-create-contract
+        templateRef:
+          name: tks-cli
+          template: create-contract
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: contract_name
+            value: "{{steps.call-generate-names.outputs.parameters.contract-name}}"
+          - name: creator
+            value: ""
+          - name: description
+            value: "e2e-test"
     - - name: call-create-usercluster
         templateRef:
           name: tks-cli
@@ -39,13 +53,13 @@ spec:
           - name: tks_client_conf
             value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
           - name: cluster_name
-            value: "{{steps.call-get-cluster-name.outputs.parameters.cluster-name}}"
+            value: "{{steps.call-generate-names.outputs.parameters.cluster-name}}"
           - name: template_name
             value: "aws-msa-reference"
-          - name: contract_id
-            value: "{{workflow.parameters.contract_id}}"
+          - name: contract_id 
+            value: "{{steps.call-create-contract.outputs.parameters.contract-id}}"
           - name: csp_id
-            value: "{{workflow.parameters.csp_id}}"
+            value: "{{steps.call-create-contract.outputs.parameters.csp-id}}"
           - name: creator
             value: ""
           - name: description
@@ -223,7 +237,7 @@ spec:
           - name: cluster_id
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
           - name: contract_id
-            value: "{{workflow.parameters.contract_id}}"            
+            value: "{{steps.call-create-contract.outputs.parameters.contract-id}}"
     # TODO: cleaup remaining AWS resources
 
   - name: notify-slack

--- a/tests/tks-e2e-aws.yaml
+++ b/tests/tks-e2e-aws.yaml
@@ -22,14 +22,28 @@ spec:
         templateRef:
           name: tks-cli
           template: create-tks-client-conf
-    - - name: call-get-cluster-name
+    - - name: call-generate-names
         templateRef:
           name: tks-e2e-test-common
-          template: get-cluster-name
+          template: generate-names
         arguments:
           parameters:
           - name: postfix
             value: "aws"
+    - - name: call-create-contract
+        templateRef:
+          name: tks-cli
+          template: create-contract
+        arguments:
+          parameters:
+          - name: tks_client_conf
+            value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
+          - name: contract_name
+            value: "{{steps.call-generate-names.outputs.parameters.contract-name}}"
+          - name: creator
+            value: ""
+          - name: description
+            value: "e2e-test"
     - - name: call-create-usercluster
         templateRef:
           name: tks-cli
@@ -39,13 +53,13 @@ spec:
           - name: tks_client_conf
             value: "{{steps.call-create-tks-client-conf.outputs.parameters.tks_client_conf}}"
           - name: cluster_name
-            value: "{{steps.call-get-cluster-name.outputs.parameters.cluster-name}}"
+            value: "{{steps.call-generate-names.outputs.parameters.cluster-name}}"
           - name: template_name
             value: "aws-reference"
           - name: contract_id 
-            value: "{{workflow.parameters.contract_id}}"
+            value: "{{steps.call-create-contract.outputs.parameters.contract-id}}"
           - name: csp_id
-            value: "{{workflow.parameters.csp_id}}"
+            value: "{{steps.call-create-contract.outputs.parameters.csp-id}}"
           - name: creator
             value: ""
           - name: description
@@ -147,7 +161,7 @@ spec:
           - name: cluster_id
             value: "{{steps.call-create-usercluster.outputs.parameters.cluster-id}}"
           - name: contract_id
-            value: "{{workflow.parameters.contract_id}}" 
+            value: "{{steps.call-create-contract.outputs.parameters.contract-id}}"
     # TODO: cleaup remaining AWS resources
 
   - name: notify-slack

--- a/tests/tks-e2e-common.yaml
+++ b/tests/tks-e2e-common.yaml
@@ -14,7 +14,7 @@ spec:
       value: "tks-cluster_lcm.tks.com:9110"
 
   templates:
-  - name: get-cluster-name
+  - name: generate-names
     inputs:
       parameters:
       - name: postfix
@@ -24,9 +24,11 @@ spec:
         - /bin/bash
         - '-exc'
         - |
-          CL_NAME="e2e-test-{{inputs.parameters.postfix}}-$(date "+%Y-%m%d-%H%M")"
+          CL_NAME="e2e-test-cl-{{inputs.parameters.postfix}}-$(date "+%Y-%m%d-%H%M")"
+          CT_NAME="e2e-test-ct-{{inputs.parameters.postfix}}-$(date "+%Y-%m%d-%H%M")"
 
           echo $CL_NAME | tee /mnt/out/cluster_name.txt
+          echo $CT_NAME | tee /mnt/out/contract_name.txt
       volumeMounts:
         - name: out
           mountPath: /mnt/out
@@ -39,6 +41,10 @@ spec:
         valueFrom:
           default: "Something wrong"
           path: /mnt/out/cluster_name.txt
+      - name: contract-name
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/contract_name.txt
 
   - name: notify-slack
     container:

--- a/tks-cli/tks-cli.yaml
+++ b/tks-cli/tks-cli.yaml
@@ -44,6 +44,54 @@ spec:
           default: "Something wrong"
           path: /mnt/out/tks-client.yaml
 
+  - name: create-contract
+    inputs:
+      parameters:
+      - name: tks_client_conf
+      - name: contract_name
+      - name: creator
+      - name: description
+    container:
+      name: create-contract
+      image: sktcloud/tks-e2e-test:v2.0.2
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          echo "{{inputs.parameters.tks_client_conf}}" | tee ~/.tks-client.yaml
+
+          CT_NAME="{{inputs.parameters.contract_name}}"
+          echo "* Create $CT_NAME contract"
+
+          OUTPUT=$(tksadmin contract create ${CT_NAME} --description "{{inputs.parameters.description}}" --creator "{{inputs.parameters.creator}}" | grep csp_id)
+          if [ "$OUTPUT" = "" ]; then
+            exit 1
+          fi
+
+          CSP_ID=$(echo $OUTPUT | cut -d'"' -f2)
+          CT_ID=$(echo $OUTPUT | cut -d'"' -f4)
+
+          sleep 1m
+
+          echo $CSP_ID | tee /mnt/out/csp_id.txt
+          echo $CT_ID | tee /mnt/out/contract_id.txt
+      volumeMounts:
+        - name: out
+          mountPath: /mnt/out
+    volumes:
+      - name: out
+        emptyDir: { }
+    outputs:
+      parameters:
+      - name: csp-id
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/csp_id.txt
+      - name: contract-id
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/contract_id.txt
+
   - name: create-usercluster
     inputs:
       parameters:


### PR DESCRIPTION
e2e test 실행시 항상 contract 를 신규로 생성하도록 추가합니다.
이 변경으로 decapod-base-yaml, decapod-site 의 변경을 테스트할 수 있습니다.

* contract 조회/삭제는 현재 API 구현이 되지 않은 상태이므로 e2e 테스트에서는 생성된 contract repo 및 db data를 삭제하지 않습니다.

