### PR TITLE
Primary cluster 생성을 위한 workflow template 추가

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -10,7 +10,7 @@ spec:
     - name: site_name
       value: "decapod-refrence"
     - name: logging_component
-      value: "efk"
+      value: "loki"
     - name: github_account
       value: "tks-management"
     - name: manifest_repo_url
@@ -23,7 +23,7 @@ spec:
     # For tks-info task #
     ##########################
     - name: tks_info_host
-      value: "tks-info.tks.svc"
+      value: "http://tks-api.tks.svc:9110"
     - name: cluster_id
       value: "Cabbead61"
     - name: app_group_id
@@ -56,7 +56,7 @@ spec:
 
     - - name: updateEndpointToTksInfo
         templateRef:
-          name: update-tks-app-group-info
+          name: tks-update-appgroup
           template: updateTksAppGroup
         arguments:
           parameters:
@@ -219,32 +219,32 @@ spec:
       emptyDir: {}
     script: 
       name: 'collect'
-      image: harbor-cicd.taco-cat.xyz/tks/python-centos-wf-worker:v2.0
+      image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
       command:
       - python
       envFrom:
       - secretRef:
           name: "git-svc-token"
-      env:
-      - name: PYTHONPATH
-        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
       volumeMounts:
-      - name: tks-proto-vol
-        mountPath: "/opt/protobuf"
-        readOnly: true
       - name: out
         mountPath: /mnt/out
       source: |
         import sys
         import os
-        import google.protobuf
-        import grpc
-        import info_pb2
-        import info_pb2_grpc
-        import common_pb2
-        import common_pb2_grpc
-        import json
         import git
+        import requests
+
+        def getToken() :
+            data = {
+                'accountId': 'admin',
+                'password' : '1234'
+            }
+
+            res = requests.post(TKS_API_URL+"/api/1.0/auth/login", json = data )
+            if res.status_code != 200 :
+                return ''
+            resJson = res.json()
+            return resJson['data']['user']['token']
 
         output_cluster_list = []
         temp_map = {}
@@ -252,11 +252,82 @@ spec:
         inwards_endpoint_map = {}
         outwards_endpoint_map = {}
 
-        ip = "{{inputs.parameters.tks_info_host}}"
-        # TODO: Make port workflow param?
-        port = 9110
-        addr = "%s:%d" % (ip, port)
-        print("tks-info addr: %s" % addr)
+
+        res = requests.get(TKS_API_URL+"/api/1.0/clusters/" + CLUSTER_ID,
+            headers={"Authorization": "Bearer " + getToken()} )
+        if res.status_code != 200 :
+            sys.exit('Failed to get cluster')
+
+        cluster = res.json()['data']['cluster']
+        print( cluster )
+        organizationId = res.cluster['organizationId']
+        curClusterName = res.cluster['id']
+
+        res = requests.get(TKS_API_URL+"/api/1.0/clusters?organizationId=" + organizationId,
+            headers={"Authorization": "Bearer " + getToken()} )
+        if res.status_code != 200 :
+            sys.exit('Failed to get clusters')
+
+        print("Iterating over clusters in the same contract...")
+
+        # Iterate over cluster list except current cluster #
+        for cluster in res.clusters:
+            if cluster['status'] != "RUNNING":
+              continue
+
+            if cluster['id'] != "{{workflow.parameters.cluster_id}}":
+              print("*******************************************")
+              print("Checking cluster: {}".format(cluster.id))
+
+              print("Checking if corresponding cluster repo exists..")
+              url = "@github.com/{{workflow.parameters.github_account}}/{}".format(cluster['id'])
+              repoUrl = "https://" + os.environ['TOKEN'] + url
+              try:
+                repo = git.Repo.clone_from(repoUrl, './tempcluster')
+
+              except git.exc.GitCommandError as e:
+                print(e)
+                print("Repo {} doesn't exist. Skipping this cluster..".format(repoUrl))
+                continue
+
+              res = requests.get(TKS_API_URL+"/api/1.0/clusters?organizationId=" + organizationId,
+                  headers={"Authorization": "Bearer " + getToken()} )
+              if res.status_code != 200 :
+                  print( 'Failed to get appgroups for cluster ')
+                  continue  
+
+              appGroups = res.json()['data']['appGroups']
+              print( appGroups ) 
+
+              os.system("rm -rf ./tempcluster")
+
+              # Check if LMA group exists.
+              for appGroup in iappGroups:
+                if appGroup['type'] == "LMA" :
+                  print("Found LMA appGroup: {}".format(appGroup['name']))
+
+                  res = requests.get(TKS_API_URL+"/api/1.0/app-groups/" + appGroup['id'] + "/applications",
+                      headers={"Authorization": "Bearer " + getToken()} )
+                  if res.status_code != 200 :
+                      print( 'Failed to get applications for appgroup')
+                      continue                  
+
+
+                  res = app_stub.GetApps(info_pb2.GetAppsRequest(app_group_id=app_group.app_group_id, type=common_pb2.PROMETHEUS))
+
+                  if res.apps:
+                    # This is based on the premise that there's only one prometheus per appGroup.
+                    endpoint = res.apps[0].endpoint
+                    print("Get Thanos-sc endpoint: {}. Appending it to inward list.".format(endpoint))
+
+                    # Add this cluster's endpoint to endpoint map
+                    inwards_endpoint_list.append(endpoint)
+
+                    # Add this cluster to outward list so that current ep is updated to this cluster
+                    temp_map["name"] = cluster.id
+                    str_json = json.dumps(temp_map)
+                    output_cluster_list.append(str_json)
+
 
         with grpc.insecure_channel(addr) as channel:
             cl_stub = info_pb2_grpc.ClusterInfoServiceStub(channel)

--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -12,11 +12,13 @@ spec:
     - name: logging_component
       value: "loki"
     - name: github_account
-      value: "tks-management"
+      value: "decapod10"
     - name: manifest_repo_url
-      value: "https://github.com/openinfradev/decapod-manifests"
+      value: "https://github.com/decapod10/c3c16juq5-manifests"
     - name: revision
       value: "main"
+    - name: organization_id
+      value: "o086tb3zc"
     - name: app_prefix
       value: "{{workflow.parameters.site_name}}"
     ##########################
@@ -25,9 +27,10 @@ spec:
     - name: tks_info_host
       value: "http://tks-api.tks.svc:9110"
     - name: cluster_id
-      value: "Cabbead61"
+      value: "c3c16juq5"
     - name: app_group_id
-      value: "Aabbead61"
+      value: "a60sfxh4v"
+
   volumes:
   - name: tks-proto-vol
     configMap:
@@ -39,8 +42,35 @@ spec:
         template: createNamespace
         arguments:
           parameters:
-            - name: target_namespace
-              value: lma
+          - name: target_namespace
+            value: lma
+
+    - - name: get-clusters-in-contract
+        templateRef:
+          name: tks-primary-cluster
+          template: sub-get-cluster
+
+    - - name: set-this-to-primary-cluster
+        templateRef:
+          name: tks-primary-cluster
+          template: set-primary-cluster
+        arguments:
+          parameters:
+          - name: primary_cluster
+            value: '{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}'
+          - name: member_clusters
+            value: '{{steps.get-clusters-in-contract.outputs.parameters.member_clusters}}'
+        when: "{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}} == null"
+
+    - - name: organization-level-update
+        template: primayCluster
+        arguments:
+          parameters:
+          - name: primary_cluster
+            value: '{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}'
+          - name: member_clusters
+            value: '{{workflow.parameters.cluster_id}}'
+        when: "{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}} != null && {{workflow.parameters.cluster_id}} != {{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}"
 
     - - name: installApps
         templateRef:
@@ -66,7 +96,7 @@ spec:
       # LMA appGroup specific task #
     - - name: collectThanosScEndpoints
         template: collectThanosScEndpoints
-        arguments:
+        arguments:====
           # These params should be moved to global argument? #
           parameters:
           - name: tks_info_host
@@ -88,7 +118,7 @@ spec:
             value: "lma"
           - name: chart
             value: "thanos"
-          - name: kv_map_str 
+          - name: kv_map_str
             value: "{'querier.stores': '{{steps.GetMyThanosScEndpoint.outputs.parameters.my_thanos_sc_ep}}'}"
         withParam: "{{steps.collectThanosScEndpoints.outputs.parameters.outwards_cluster_list}}"
 
@@ -151,6 +181,72 @@ spec:
     retryStrategy:
       limit: 2
 
+  - name: primayCluster
+    inputs:
+      parameters:
+      - name: primary_cluster
+      - name: member_clusters
+    container:
+      name: logging-target-changer
+      image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.6
+      command:
+      - /bin/bash
+      - '-c'
+      - |
+
+        function log() {
+          level=$1
+          msg=$2
+          date=$(date '+%F %H:%M:%S')
+          echo "[$date] $level     $msg"
+        }
+
+        # Check endpoints from the primary_cluster
+        primary_cluster={{inputs.parameters.primary_cluster}}
+        echo __${primary_cluster}__
+        if [ -z primary_cluster ] || [ primary_cluster="null" ]; then
+          primary_cluster={{workflow.parameters.cluster_id}}
+        fi
+
+        echo kubectl get secret -n ${primary_cluster} ${primary_cluster}-kubeconfig -o jsonpath="{.data.value}"
+        primary_kube_secret=$(kubectl get secret -n ${primary_cluster} ${primary_cluster}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        echo -e "primary_kube_secret:\n$primary_kube_secret" | head -n 5
+        cat <<< "$primary_kube_secret" > kubeconfig
+
+        while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]
+        do
+          echo "Waiting for generating the loadbalancer of LOKI(3s)"
+          sleep 3
+        done
+
+        LOKI_HOST=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+        LOKI_PORT=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.spec.ports[0].port}")
+        THANOS_HOST=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+        THANOS_PORT=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.spec.ports[0].port}")
+        THANOS_URL=${THANOS_HOST}:${THANOS_PORT}
+
+        echo "DEBUG: received parameters: {{inputs.parameters.primary_cluster}}:{{inputs.parameters.member_clusters}}:{{workflow.parameters.cluster_id}} "
+        echo "DEBUG: for the input i get: $LOKI_HOST $LOKI_PORT $THANOS_HOST $THANOS_PORT"
+        exit 0
+
+        # update primary
+
+        kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        echo -e "kube_secret:\n$kube_secret" | head -n 5
+        cat <<< "$kube_secret" > /etc/kubeconfig
+
+        kubectl --kubeconfig=/etc/kubeconfig get ns ${TARGET_NAMESPACE}
+        if [[ $? =~ 1 ]]; then
+          kubectl --kubeconfig=/etc/kubeconfig create ns ${TARGET_NAMESPACE}
+          kubectl --kubeconfig=/etc/kubeconfig label ns ${TARGET_NAMESPACE} name=${TARGET_NAMESPACE}
+          kubectl --kubeconfig=/etc/kubeconfig label ns ${TARGET_NAMESPACE} taco-tls=enabled
+          log "INFO" "${TARGET_NAMESPACE} successfully created."
+        fi
+
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+
   - name: GetMyThanosScEndpoint
     inputs:
       parameters:
@@ -193,7 +289,6 @@ spec:
             echo "$thanos_sc_ep:$THANOS_SC_PORT" > /mnt/out/thanos_sc_ep.txt
           fi
 
-
   - name: collectThanosScEndpoints
     inputs:
       parameters:
@@ -213,7 +308,7 @@ spec:
     volumes:
     - name: out
       emptyDir: {}
-    script: 
+    script:
       name: 'collect'
       image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
       command: ["python"]
@@ -306,10 +401,10 @@ spec:
                   headers={"Authorization": "Bearer " + TOKEN} )
               if res.status_code != 200 :
                   print( 'Failed to get appgroups for cluster ')
-                  continue  
+                  continue
 
               appGroups = res.json()['appGroups']
-              print( appGroups ) 
+              print( appGroups )
 
               os.system("rm -rf ./tempcluster")
 
@@ -324,7 +419,7 @@ spec:
                       print( 'Failed to get applications for appgroup')
                       continue
 
-                  applications = res.json()['applications']            
+                  applications = res.json()['applications']
 
                   if applications :
                     # This is based on the premise that there's only one prometheus per appGroup.
@@ -340,7 +435,7 @@ spec:
                     output_cluster_list.append(str_json)
 
 
-        # Compose profer format to be used as input on next step 
+        # Compose profer format to be used as input on next step
         inwards_endpoint_map['querier.stores'] = inwards_endpoint_list
 
         ###########################

--- a/deploy_apps/tks-primary-cluster.yaml
+++ b/deploy_apps/tks-primary-cluster.yaml
@@ -1,0 +1,478 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-primary-cluster
+  namespace: argo
+spec:
+  entrypoint: set-primary-cluster
+  arguments:
+    parameters:
+    ##########################
+    # needed by sub-systems (sub-template)
+    ##########################
+    - name: site_name  # primary cluster
+      value: site3
+    - name: revision
+      value: "main"
+    - name: app_prefix
+      value: "{{workflow.parameters.site_name}}"
+    - name: repository_base
+      value: https://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@github.com/overmon/
+    - name: github_account
+      value: "decapod10"
+
+    ##########################
+    # For tks-info task #
+    ##########################
+    - name: tks_info_host
+      value: "http://tks-api-dev.taco-cat.xyz:9110"
+    - name: organization_id
+      value: "o086tb3zc"
+    # 아마도 site_name과 동일하게 사용하면 될듯하다.
+    - name: cluster_id
+      value: "{{workflow.parameters.site_name}}"
+
+  volumes:
+  - name: tks-proto-vol
+    configMap:
+      name: tks-proto
+
+  templates:
+  - name: set-primary-cluster
+    inputs:
+      parameters:
+      - name: primary_cluster
+      - name: member_clusters
+    steps:
+    - - name: update-status-mainternance
+        template: sub-update-tks-status
+        arguments:
+          parameters:
+          - name: tks_status
+            value: MAINTERNANCE
+      # - name: get-clusters-in-contract
+      #   template: sub-get-cluster
+    - - name: set-primary-cluster-on-tks-info
+        template: sub-set-primay-cluster-on-tks-info
+      - name: create-fed-namespace
+        template: sub-create-namespace
+        arguments:
+          parameters:
+          - name: target_namespace
+            value: fed
+
+    # TODO: 전체 완성을 위해서는 아래내역을 구현하여 동적인 bucket을 만드는 방식으로 구현해야 하지만
+    #     5월 오픈전 가능한 형상을 위해 협의한 바(아래)에 따라 본부분은 기존 준비됀 것을 사용하는 것으로 구현하고 추후 수정하다.
+    #       1. 사용자가 생성하는 첫번째 클러스터는 primary cluster
+    #       2. primary cluster는 계약이 종료되기 전까지 임의 삭제불가
+    #       3. 개별 클러스터에서 수행되는 모니터링은 없고 계약단위에서 수행되어야 함
+    # - - name: prepare-bucket
+    #     templateRef:
+    #       name: create-application
+    #       template: installApps
+    #     arguments:
+    #       parameters:
+    #       - name: list
+    #         value: |
+    #           [
+    #             { "app_group": "tks-cluster", "path": "ack-resources", "namespace": "taco-system", "target_cluster": "" }
+    #           ]
+
+    # 개별 클러스터에 설치됀 loki와 grafana는 지우자
+    # - - name: remove-individual-loki-and-grafana
+    #     template: sub-remove-individual-loki-and-grafana
+    #     arguments:
+    #       parameters:
+    #       - name: target_clusters
+    #         value: '{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}} {{steps.get-clusters-in-contract.outputs.parameters.member_clusters}}'
+
+    # TODO: 전체 완성을 위해서는 아래내역을 구현하여 동적인 bucket을 만드는 방식으로 구현해야 하지만
+    #     5월 오픈전 가능한 형상을 위해 협의한 바(아래)에 따라 본부분은 기존 준비됀 것을 사용하는 것으로 구현하고 추후 수정하다.
+    #       1. 사용자가 생성하는 첫번째 클러스터는 primary cluster
+    #       2. primary cluster는 계약이 종료되기 전까지 임의 삭제불가
+    #       3. 개별 클러스터에서 수행되는 모니터링은 없고 계약단위에서 수행되어야 함
+    # 하지만 이부분에 datasource 바꿔주는 부분을 포함하고 있으므로 일단 한번 타야할듯...
+    - - name: change-target
+        template: sub-change-logging-target
+        arguments:
+          parameters:
+          - name: primary_cluster
+            value: '{{inputs.parameters.primary_cluster}}'
+          - name: member_clusters
+            value: '{{inputs.parameters.member_clusters}}'
+
+    - - name: federation-components
+        templateRef:
+          name: create-application
+          template: installApps
+        arguments:
+          parameters:
+          - name: list
+            value: |
+              [
+                { "app_group": "primary", "path": "minio", "namespace": "fed", "target_cluster": "" }
+                { "app_group": "primary", "path": "thanos", "namespace": "fed", "target_cluster": "" }
+                { "app_group": "primary", "path": "loki", "namespace": "fed", "target_cluster": "" }
+                { "app_group": "primary", "path": "grafana", "namespace": "fed", "target_cluster": "" }
+              ]
+
+    - - name: update-status-done
+        template: sub-update-tks-status
+        arguments:
+          parameters:
+          - name: tks_status
+            value: Running
+
+  #######################
+  # Template Definition #
+  #######################
+  - name: sub-update-tks-status
+    inputs:
+      parameters:
+      - name: tks_status
+    container:
+      name: update-tks-status
+      image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.6
+      command:
+      - /bin/bash
+      - '-c'
+      - |
+        echo "check tks status"
+        echo "if status is not running then throw exception~~"
+        echo "connect tks-info server and change the {{workflow.parameters.organization_id}} status to mode:{{inputs.parameters.tks_status}}"
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+
+  # - name: sub-prepare-bucket
+  #   inputs:
+  #     parameters:
+  #     - name: primary_cluster
+  #   container:
+  #     name: prepare-bucket
+  #     image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.6
+  #     command:
+  #     - /bin/bash
+  #     - '-c'
+  #     - |
+  #       echo "prepare bucket for the '{{workflow.parameters.organization_id}}' (clusters: '{{inputs.parameters.primary_cluster}}')"
+  #   activeDeadlineSeconds: 900
+  #   retryStrategy:
+  #     limit: 2
+
+  - name: sub-create-namespace
+    inputs:
+      parameters:
+        - name: target_namespace
+    container:
+      name: create-namespace
+      image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.6
+      command:
+      - /bin/bash
+      - '-c'
+      - |
+        function log() {
+          level=$1
+          msg=$2
+          date=$(date '+%F %H:%M:%S')
+          echo "[$date] $level     $msg"
+        }
+
+        kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        echo -e "kube_secret:\n$kube_secret" | head -n 5
+        cat <<< "$kube_secret" > /etc/kubeconfig
+
+        kubectl --kubeconfig=/etc/kubeconfig get ns ${TARGET_NAMESPACE}
+        if [[ $? =~ 1 ]]; then
+          kubectl --kubeconfig=/etc/kubeconfig create ns ${TARGET_NAMESPACE}
+          kubectl --kubeconfig=/etc/kubeconfig label ns ${TARGET_NAMESPACE} name=${TARGET_NAMESPACE}
+          kubectl --kubeconfig=/etc/kubeconfig label ns ${TARGET_NAMESPACE} taco-tls=enabled
+          log "INFO" "${TARGET_NAMESPACE} successfully created."
+        fi
+      env:
+      - name: TARGET_NAMESPACE
+        value: '{{inputs.parameters.target_namespace}}'
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+
+  - name: sub-change-logging-target
+    inputs:
+      parameters:
+      - name: primary_cluster
+      - name: member_clusters
+    container:
+      name: logging-target-changer
+      image: harbor-cicd.taco-cat.xyz/tks/shyaml_python:3.11
+      command:
+      - /bin/bash
+      - '-c'
+      - |
+        #/bin/bash
+
+        set -ex
+
+        function log() {
+          level=$1
+          msg=$2
+          date=$(date '+%F %H:%M:%S')
+          echo "[$date] $level  $msg"
+        }
+
+        current_cluster={{workflow.parameters.cluster_id}}
+        primary_cluster={{inputs.parameters.primary_cluster}}
+
+        if [ -z ${primary_cluster} ] || [ ${primary_cluster}="null" ]; then
+          primary_cluster=${current_cluster}
+        fi
+
+        #################
+        # Check endpoints from the primary_cluster
+        #################
+        echo kubectl get secret -n ${primary_cluster} ${primary_cluster}-kubeconfig -o jsonpath="{.data.value}"
+        primary_kube_secret=$(kubectl get secret -n ${primary_cluster} ${primary_cluster}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        echo -e "primary_kube_secret:\n$primary_kube_secret" | head -n 5
+        cat <<< "$primary_kube_secret" > kubeconfig
+
+        while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]
+        do
+          echo "Waiting for generating the loadbalancer of LOKI(3s)"
+          sleep 3
+        done
+
+        LOKI_HOST=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+        LOKI_PORT=$(kubectl --kubeconfig=kubeconfig get svc -n lma loki-loki-distributed-gateway -o jsonpath="{.spec.ports[0].port}")
+        METRIC_HOST=$(kubectl --kubeconfig=kubeconfig get svc -n lma minio -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
+        METRIC_PORT=$(kubectl --kubeconfig=kubeconfig get svc -n lma minio -o jsonpath="{.spec.ports[0].port}")
+        METRIC_URL=${METRIC_HOST}:${METRIC_PORT}
+
+        #################
+        # updates
+        #################
+        GIT_ACCOUNT={{workflow.parameters.github_account}}
+        if  [[ $GIT_SVC_URL == https://* ]]; then
+          repository_base=https://${TOKEN//[$'\t\r\n ']}@${GIT_SVC_URL/http:\/\//}/${GIT_ACCOUNT}/
+        else
+          repository_base=http://${TOKEN//[$'\t\r\n ']}@${GIT_SVC_URL/http:\/\//}/${GIT_ACCOUNT}/
+        fi
+
+        for i in {{inputs.parameters.member_clusters}}
+        do
+          # 1. endpoint of fb on eachcluster
+          log "INFO" "##### change the loki target to $LOKI_HOST:$LOKI_PORT and $METRIC_URL (the current target is $i)"
+          [ -d $i ] || git clone ${repository_base}${i}
+          cd $i
+          sed -i "s/lokiHost: *$(cat ${i}/lma/site-values.yaml | shyaml get-value global.lokiHost)/lokiHost: $LOKI_HOST/g" ${i}/lma/site-values.yaml
+          sed -i "s/lokiPort: *$(cat ${i}/lma/site-values.yaml | shyaml get-value global.lokiPort)/lokiPort: $LOKI_PORT/g" ${i}/lma/site-values.yaml
+          sed -i "s/s3Host: *$(cat ${i}/lma/site-values.yaml | shyaml get-value global.s3Host)/s3Host: $METRIC_HOST/g" ${i}/lma/site-values.yaml
+          sed -i "s/s3Port: *$(cat ${i}/lma/site-values.yaml | shyaml get-value global.s3Port)/s3Port: $METRIC_PORT/g" ${i}/lma/site-values.yaml
+
+          # 2. grafana datasource on primay_cluster
+          if [ $i = ${primary_cluster} ]; then
+            sed -i "s/grafanaDatasourceMetric: *$(cat ${i}/lma/site-values.yaml | shyaml get-value global.grafanaDatasourceMetric)/grafanaDatasourceMetric: thanos-query.lma:9090/g" ${i}/lma/site-values.yaml
+          fi
+          cd -
+        done
+
+        git config --global user.name "tks"
+        git config --global user.email "tks@sktelecom.com"
+
+        for i in {{inputs.parameters.member_clusters}}
+        do
+          cd $i
+          log "INFO" "##### commit changes on $i to $LOKI_HOST:$LOKI_PORT and $METRIC_URL"
+          cmessage="the loki to $LOKI_HOST:$LOKI_PORT and grafana to $METRIC_URL (cluster $i)"
+          git add ${i}/lma/site-values.yaml
+          git commit -m "change loki and thanos endpoints. (by set-primary workflow)" -m "$cmessage"
+          git push
+          cd -
+          rm -rf $i
+        done
+
+      envFrom:
+      - secretRef:
+          name: "git-svc-token"
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+
+  - name: sub-remove-individual-loki-and-grafana
+    inputs:
+      parameters:
+      - name: target-clusters
+    container:
+      name: delete-loki
+      image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.6
+      command:
+      - /bin/bash
+      - '-c'
+      - |
+        # log into Argo CD server
+        ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
+        --password $ARGO_PASSWORD
+
+        for cid in {{inputs.parameters.target-clusters}}
+        do
+          for app in loki grafana
+          do
+            APP=${cid}-${app}
+
+            # Pre-check: validate if the app exists
+            if ! (./argocd app list --output name | grep -E "^$APP$"); then
+              echo "No such app: $APP. Skipping app removal.."
+              exit 1
+            fi
+          done
+        done
+
+        for cid in {{inputs.parameters.target-clusters}}
+        do
+          for app in loki grafana
+          do
+            APP=${cid}-${app}
+            echo "Found app '$APP'. Start deleting it.."
+            ./argocd app delete $APP --cascade -y
+
+            while (./argocd app list --output name | grep -E "^$APP$" )
+            do
+              echo "Waiting 20 secs for the app to be deleted.."
+              sleep 20
+            done
+
+            echo "App '$APP' have been deleted!"
+          done
+        done
+
+      envFrom:
+        - secretRef:
+            name: "decapod-argocd-config"
+    activeDeadlineSeconds: 900
+
+  - name: sub-get-cluster
+    volumes:
+    - name: out
+      emptyDir: {}
+    script:
+      image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
+      command: ["python"]
+      env:
+      - name: PYTHONPATH
+        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
+      - name: TKS_API_URL
+        value: "{{workflow.parameters.tks_info_host}}"
+      volumeMounts:
+      - name: out
+        mountPath: /mnt/out
+      source: |
+        import sys
+        import requests
+        import json
+
+        TKS_API_URL = "{{workflow.parameters.tks_info_host}}"
+        ORGANIZATION_ID = "{{workflow.parameters.organization_id}}"
+        CLUSTER_ID = "{{workflow.parameters.cluster_id}}"
+
+        def getToken() :
+          data = {
+            'organizationId' : 'master',
+            'accountId': 'admin',
+            'password' : 'admin'
+          }
+
+          res = requests.post(TKS_API_URL+"/api/1.0/auth/login", json = data )
+          if res.status_code != 200 :
+              return ''
+          resJson = res.json()
+          return resJson['user']['token']
+
+        # get primary organization id
+        res = requests.get(TKS_API_URL+"/api/1.0/organizations/" + ORGANIZATION_ID, headers={"Authorization": "Bearer " + getToken(), "Content-Type" : "application/json"} )
+        if res.status_code != 200 :
+          sys.exit('Failed to get organization')
+
+        print(res.text)
+        organization = res.json()['organization']
+
+        with open("/mnt/out/primary_cluster.txt", "w") as f:
+          primary_cluster = json.dumps(organization.get('primaryClusterId'))
+          print('Primary cluster: ', primary_cluster)
+          f.write(primary_cluster)
+
+        # get cluster ids
+        res = requests.get(TKS_API_URL+"/api/1.0/clusters?organizationId=" + ORGANIZATION_ID, headers={"Authorization": "Bearer " + getToken(), "Content-Type" : "application/json"} )
+        if res.status_code != 200 :
+          sys.exit('Failed to get clusters')
+
+        # print(res.text)
+        clusters = res.json()['clusters']
+
+        with open("/mnt/out/member_clusters.txt", "w") as f:
+          for cluster in clusters:
+            print('Member cluster: ',cluster['id'])
+            f.write(cluster['id']+' ')
+
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+
+    outputs:
+      parameters:
+      - name: primary_cluster
+        valueFrom:
+          path: /mnt/out/primary_cluster.txt
+      - name: member_clusters
+        valueFrom:
+          path: /mnt/out/member_clusters.txt
+
+
+  - name: sub-set-primay-cluster-on-tks-info
+    volumes:
+    - name: out
+      emptyDir: {}
+    script:
+      image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
+      command: ["python"]
+      env:
+      - name: PYTHONPATH
+        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
+      - name: TKS_API_URL
+        value: "{{workflow.parameters.tks_info_host}}"
+      volumeMounts:
+      - name: out
+        mountPath: /mnt/out
+      source: |
+        import sys
+        import requests
+        import json
+
+        TKS_API_URL = "{{workflow.parameters.tks_info_host}}"
+        ORGANIZATION_ID = "{{workflow.parameters.organization_id}}"
+        CLUSTER_ID = "{{workflow.parameters.cluster_id}}"
+
+        def getToken() :
+          data = {
+            'organizationId' : 'master',
+            'accountId': 'admin',
+            'password' : 'admin'
+          }
+
+          res = requests.post(TKS_API_URL+"/api/1.0/auth/login", json = data )
+          if res.status_code != 200 :
+              return ''
+          resJson = res.json()
+          return resJson['user']['token']
+
+        # set primary cluster with this cluster
+        # api/1.0/organizations/c3c16juq5/primary-cluster
+        res = requests.patch(TKS_API_URL+"/api/1.0/organizations/"+ ORGANIZATION_ID + "/primary-cluster",
+                              headers={"Authorization": "Bearer " + getToken(), "Content-Type" : "application/json"},
+                              data=json.dumps({"primaryClusterId": CLUSTER_ID})
+                            )
+        if res.status_code != 200 :
+          print(res.reason)
+          sys.exit('Failed to set primary-cluster at organization')
+
+    activeDeadlineSeconds: 900
+    retryStrategy:
+      limit: 2
+

--- a/dockerfiles/Dockerfile.shyaml
+++ b/dockerfiles/Dockerfile.shyaml
@@ -1,0 +1,6 @@
+FROM python:3.11
+# COPY kubectl /usr/bin/kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/bin/kubectl
+RUN mv kubectl /usr/bin/
+RUN chmod +x /usr/bin/kubectl
+RUN pip install shyaml

--- a/dockerfiles/Dockerfile.tks-api
+++ b/dockerfiles/Dockerfile.tks-api
@@ -1,0 +1,8 @@
+FROM harbor-cicd.taco-cat.xyz/tks/python-centos-wf-worker:v2.0 AS base
+USER root
+
+RUN yum install -y epel-release
+RUN yum install -y jq
+RUN pip3 install requests
+
+

--- a/git-repo/Dockerfile
+++ b/git-repo/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine/git:v2.30.2
 #FROM alpine:3.14
 
-RUN apk add --no-cache curl coreutils bash
+RUN apk add --no-cache curl coreutils bash jq
 #RUN apk add --no-cache libc6-compat
 
 ENV GITHUB_CLI_VERSION 2.5.1

--- a/git-repo/create-cluster-repo.yaml
+++ b/git-repo/create-cluster-repo.yaml
@@ -22,7 +22,7 @@ spec:
       - name: cluster_info
     container:
       name: 'createClusterRepo'
-      image: harbor-cicd.taco-cat.xyz/tks/ghcli-alpine:2.0.0
+      image: harbor-cicd.taco-cat.xyz/tks/ghcli-alpine:2.0.1
       imagePullPolicy: IfNotPresent
       command:
       - /bin/bash
@@ -69,21 +69,18 @@ spec:
 
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
 
-        echo $CLUSTER_INFO
 
         ## Replace site-values with fetched params ##
         sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
         case $INFRA_PROVIDER in
           aws)
             ## Fetch cluster params from cluster_info file ##
-            val_ssh_key=$(echo $CLUSTER_INFO | sed 's/.*\(ssh_key_name:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            echo "ssh_key_name: $val_ssh_key"
-            val_region=$(echo $CLUSTER_INFO | sed 's/.*\(region:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            val_num_of_az=$(echo $CLUSTER_INFO | sed 's/.*\(num_of_az:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            val_machine_type=$(echo $CLUSTER_INFO | sed 's/.*\(machine_type:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            val_min_size=$(echo $CLUSTER_INFO | sed 's/.*\(min_size_per_az:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            val_max_size=$(echo $CLUSTER_INFO | sed 's/.*\(max_size_per_az:\ \S*\).*/\1/' | cut -d ':' -f2 | xargs)
-            echo "max_size_per_az: $val_max_size"
+            val_ssh_key=$(echo $CLUSTER_INFO | jq -r '.sshKeyName')
+            val_region=$(echo $CLUSTER_INFO | jq -r '.region')
+            val_num_of_az=$(echo $CLUSTER_INFO | jq -r '.numOfAz')
+            val_machine_type=$(echo $CLUSTER_INFO | jq -r '.machineType')
+            val_min_size=$(echo $CLUSTER_INFO | jq -r '.minSizePerAz')
+            val_max_size=$(echo $CLUSTER_INFO | jq -r '.maxSizePerAz')
 
             sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             sed -i "s/sshKeyName:\ CHANGEME/sshKeyName: $val_ssh_key/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml

--- a/git-repo/render-manifests.yaml
+++ b/git-repo/render-manifests.yaml
@@ -24,7 +24,7 @@ spec:
     - name: git_repo_type
       value: github
     - name: https_enabled
-      value: "true"
+      value: "false"
 
   templates:
   #=========================================================

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -24,7 +24,7 @@ spec:
     - name: app_prefix
       value: "{{workflow.parameters.cluster_id}}"
     - name: tks_info_host
-      value: "tks-info.tks.svc"
+      value: "http://tks-api.tks.svc:9110"
 
   volumes:
   - name: kubeconfig-adm

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -180,7 +180,7 @@ spec:
         echo ${INFRA_PROVIDER} | tee /mnt/out/infra_provider.txt
 
         if [ "$INFRA_PROVIDER" = "aws" ]; then
-            eks_enabled=$(cat ${CLUSTER_ID}/$TEMPLATE_NAME/tks-cluster/site-values.yaml  | grep eksEnabled | awk '{print $2}')
+            eks_enabled=$(cat ${CLUSTER_ID}/${CLUSTER_ID}/tks-cluster/site-values.yaml  | grep eksEnabled | awk '{print $2}')
             echo $eks_enabled | tee /mnt/out/managed_cluster.txt
         fi
       envFrom:

--- a/tks_info/get-tks-cluster-wftpl.yaml
+++ b/tks_info/get-tks-cluster-wftpl.yaml
@@ -8,13 +8,9 @@ spec:
   arguments:
     parameters:
     - name: tks_info_host
-      value: "tks-info.tks.svc"
+      value: "http://tks-api-dev.taco-cat.xyz:9110"
     - name: cluster_id
-      value: "Cabbead61"
-  volumes:
-  - name: tks-proto-vol
-    configMap:
-      name: tks-proto
+      value: "cabbead61"  
   templates:
   - name: getTksCluster
     outputs:
@@ -26,40 +22,47 @@ spec:
     - name: out
       emptyDir: {}
     script:
-      image: harbor-cicd.taco-cat.xyz/tks/python-centos-wf-worker:v2.0
+      image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
       command: ["python"]
       env:
       - name: PYTHONPATH
         value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
+      - name: TKS_API_URL
+        value: "{{workflow.parameters.tks_info_host}}"        
       volumeMounts:
-      - name: tks-proto-vol
-        mountPath: "/opt/protobuf"
-        readOnly: true
       - name: out
         mountPath: /mnt/out
       source: |
         import sys
-        import google.protobuf
-        import grpc
-        import info_pb2
-        import info_pb2_grpc
-        import common_pb2
-        import common_pb2_grpc
+        import requests
+        import json
 
-        ip = "{{workflow.parameters.tks_info_host}}"
-        port = 9110 # if not specified
-        addr = "%s:%d" % (ip, port)
-        print("tks-info addr: %s" % addr)
+        TKS_API_URL = "{{workflow.parameters.tks_info_host}}"
+        CLUSTER_ID = "{{workflow.parameters.cluster_id}}"
 
-        with grpc.insecure_channel(addr) as channel:
-            stub = info_pb2_grpc.ClusterInfoServiceStub(channel)
+        def getToken() :
+            data = {
+                'organizationId' : 'master',
+                'accountId': 'admin',
+                'password' : 'admin'
+            }
 
-            res = stub.GetCluster(info_pb2.GetClusterRequest(cluster_id="{{workflow.parameters.cluster_id}}"))
-            print("Response code from GetCluster: %d" % res.code)
-            print("Cluster object from GetCluster:")
-            print(res.cluster)
+            res = requests.post(TKS_API_URL+"/api/1.0/auth/login", json = data )
+            if res.status_code != 200 :
+                return ''
+            resJson = res.json()
+            return resJson['user']['token']
 
-            with open("/mnt/out/cluster_info.txt", "w") as f:
-                cluster_conf = repr(res.cluster.conf)
-                print(cluster_conf)
-                f.write(cluster_conf)
+
+        res = requests.get(TKS_API_URL+"/api/1.0/clusters/" + CLUSTER_ID, headers={"Authorization": "Bearer " + getToken(), "Content-Type" : "application/json"} )
+        if res.status_code != 200 :
+            sys.exit('Failed to get cluster')
+
+        print(res.text)
+        cluster = res.json()['cluster']
+
+        with open("/mnt/out/cluster_info.txt", "w") as f:
+            #cluster_conf = str(cluster['conf'])
+            cluster_conf = json.dumps(cluster['conf'])
+            print(cluster_conf)
+            f.write(cluster_conf)

--- a/tks_info/tks-create-tks-api-secret.yaml
+++ b/tks_info/tks-create-tks-api-secret.yaml
@@ -1,0 +1,31 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: tks-create-tks-api-secret
+  namespace: argo
+spec:
+  entrypoint: createTksApiSecret
+  arguments:
+    parameters:
+    - name: account
+      value: "admin"
+    - name: password
+      value: "1234"
+    - name: tks_api_url
+      value: "http://tks-api.tks.svc:9110"
+  templates:
+  - name: createTksApiSecret
+    activeDeadlineSeconds: 120
+    container:
+      name: 'createTksApiSecret'
+      image: harbor-cicd.taco-cat.xyz/tks/hyperkube:v1.18.8
+      imagePullPolicy: IfNotPresent
+      command:
+      - /bin/bash
+      - -ecx
+      - |
+        kubectl delete secret -n argo tks-api-secret || true
+        kubectl create secret generic tks-api-secret \
+          --from-literal=ACCOUNT="{{workflow.parameters.account}}" \
+          --from-literal=PASSWORD="{{workflow.parameters.password}}" \
+          -n argo

--- a/tks_info/update-tks-app-group-wftpl.yaml
+++ b/tks_info/update-tks-app-group-wftpl.yaml
@@ -1,52 +1,57 @@
 apiVersion: argoproj.io/v1alpha1
 kind: WorkflowTemplate
 metadata:
-  name: update-tks-app-group-info
+  name: tks-update-appgroup
   namespace: argo
 spec:
   entrypoint: updateTksAppGroup
   arguments:
     parameters:
     - name: tks_info_host
-      value: "127.0.0.1"
+      value: "http://tks-api.tks.svc:9110"
     - name: app_group_id
-      value: "Aabbead61"
-  volumes:
-  - name: tks-proto-vol
-    configMap:
-      name: tks-proto
+      value: "abcdefghi"
   templates:
   - name: updateTksAppGroup
     inputs:
       parameters:
       - name: endpoints # Dict type
     script:
-      image: harbor-cicd.taco-cat.xyz/tks/python-centos-wf-worker:v2.0
+      image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
       command: ["python"]
       env:
       - name: PYTHONPATH
-        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"
-      volumeMounts:
-      - name: tks-proto-vol
-        mountPath: "/opt/protobuf"
-        readOnly: true
+        value: "/opt/protobuf/:/opt/rh/rh-python38/root/lib/python3.8/site-packages/:/opt/app-root/lib/python3.8/site-packages/"      
       source: |
         import sys
-        import google.protobuf
-        import grpc
-        import info_pb2
-        import info_pb2_grpc
-        import common_pb2
-        import common_pb2_grpc
+        import requests
 
-        ip = "{{workflow.parameters.tks_info_host}}"
-        port = 9110 # if not specified
-        addr = "%s:%d" % (ip, port)
-        print("tks-info addr: %s" % addr)
+        TKS_API_URL = "{{workflow.parameters.tks_info_host}}"
+        APPGROUP_ID = "{{workflow.parameters.app_group_id}}"
+        ENDPOINTS = "{{inputs.parameters.endpoints}}"
 
-        with grpc.insecure_channel(addr) as channel:
-            app_stub = info_pb2_grpc.AppInfoServiceStub(channel)
+        def getToken() :
+            data = {
+                'organizationId': 'master'
+                'accountId': 'admin',
+                'password' : 'admin'
+            }
 
-            for app_type_, ep in {{inputs.parameters.endpoints}}.items():
-              res = app_stub.UpdateApp(info_pb2.UpdateAppRequest(app_group_id="{{workflow.parameters.app_group_id}}", app_type=app_type_, endpoint=ep, metadata="{}"))
-              print("Response code from UpdateApp: %d" % res.code)
+            res = requests.post(TKS_API_URL+"/api/1.0/auth/login", json = data )
+            if res.status_code != 200 :
+                return ''
+            resJson = res.json()
+            return resJson['data']['user']['token']
+
+        print( ENDPOINTS )
+        for appType, endpoint in {{inputs.parameters.endpoints}}.items() :
+            data = {
+                'appGroupId' : APPGROUP_ID,
+                'applicationType' : appType,
+                'endpoint' : endpoint
+            }
+            res = requests.post(TKS_API_URL + '/api/1.0/app-groups/' + APPGROUP_ID + '/applications' , headers={'Authorization': 'Bearer ' + getToken()}, json = data )
+            print("Response code from UpdateApplication : %d" % res.status_code)
+
+
+


### PR DESCRIPTION
내부적으로 기존 lma 설치로직에서 호출하며 각 수정은 다음을 포함한다.

### tks-lma-federation
- 자신의 조직(org)의 현황에 따라 분기 필요
- 없으면 자기가 primary가 되야 하고 set-primary-cluster 호출
- 이미 primary가 있다면 자신의 설정 중 loki 부분을 변경해야 함
### tks-primary-cluster
- 입력 파라미터는
    - primary_cluster
    - member_clusters
- 활용하는 workflow변수는
    - organization_id
    - cluster id
    - tks_info_host
- *일단 상태관련 내역은 추후로 미뤄두고 → 이건 state machine 정의하고 컨세서스 이룬후 진행하는 것이 맞음 (현재 상태는 echo만)*
- 들어오면 namespace 만들어주고
- sub-set-primay-cluster-on-tks-info
    - tks-info에 자신을 등록하고.
- sub-change-logging-target
    - 필요한 endpoint를 primary에서 구해내고
    - 상황에 맞게 update 수행
    - 입력변수로 primay_cluster와 member_clusters를 받는데 member_clusters를 조절함으로써 primary가 정해진 상황에서 만들어지는 클러스터에서도 해당 함수를 활용
        - tks-lma-federation에서 다음 함수 참조            
        ```python
        - - name: organization-level-update
                template: primayCluster
                arguments:
                  parameters:
                  - name: primary_cluster
                    value: '{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}'
                  - name: member_clusters
                    value: '{{workflow.parameters.cluster_id}}'
                when: "{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}} != null && {{workflow.parameters.cluster_id}} != {{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}"
        ```