### PR TITLE
add support for multi-tenancy aws clusters

### DIFF
--- a/git-repo/create-cluster-repo.yaml
+++ b/git-repo/create-cluster-repo.yaml
@@ -13,6 +13,8 @@ spec:
       value: "cluster_uuid"
     - name: template_name
       value: "aws-reference"
+    - name: cloud_account_id
+      value: "NULL"
 
   templates:
   - name: createClusterRepo
@@ -33,7 +35,6 @@ spec:
 
             gh repo create ${USERNAME}/${CLUSTER_ID} --public --confirm
             gh repo create ${USERNAME}/${CLUSTER_ID}-manifests --public --confirm
-
         }
 
         function gitea_create_repo() {
@@ -69,7 +70,6 @@ spec:
 
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
 
-
         ## Replace site-values with fetched params ##
         sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
         case $INFRA_PROVIDER in
@@ -91,6 +91,13 @@ spec:
             sed -i "s/mdMaxSizePerAz:\ CHANGEME/mdMaxSizePerAz: $val_max_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             sed -i "s/mdMachineType:\ CHANGEME/mdMachineType: $val_machine_type/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             sed -i "s/cpReplicas:\ CHANGEME/cpReplicas: 3/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+
+            ## multi-tenancy ##
+            if [ "$CLOUD_ACCOUNT_ID" = "NULL" ]; then
+              sed -i '/multitenancyId/,+2d' $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            else
+              sed -i "s/cloudAccountID:\ CHANGEME/cloudAccountID: $CLOUD_ACCOUNT_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            fi
             ;;
 
           byoh)
@@ -142,6 +149,8 @@ spec:
         value: "{{workflow.parameters.cluster_id}}"
       - name: TEMPLATE_NAME
         value: "{{workflow.parameters.template_name}}"
+      - name: CLOUD_ACCOUNT_ID
+        value: "{{workflow.parameters.cloud_account_id}}"
       - name: CLUSTER_INFO
         value: "{{inputs.parameters.cluster_info}}"
       volumeMounts:

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -13,6 +13,8 @@ spec:
       value: "C011b88fa"
     - name: site_name
       value: "{{ workflow.parameters.cluster_id }}"
+    - name: cloud_account_id
+      value: "NULL"
     - name: template_name
       value: "aws-reference"
     - name: git_account


### PR DESCRIPTION
아래 PR이 먼저 머지되어야 합니다.
* https://github.com/openinfradev/helm-charts/pull/175
* https://github.com/openinfradev/decapod-base-yaml/pull/211
* https://github.com/openinfradev/decapod-site/pull/124

클러스터 생성 시 cloud_account_id 파라미터가 전달된다면 멀티테넌시 클러스터로 생성하며, 그렇지 않은 경우 CAPA 컨트롤러가 사용하는 AWS Credential을 사용하여 (기존 방식) 클러스터를 생성합니다.