### PR TITLE
TKS 내부 사용 Cluster kubeconfig 시크릿 일원화

### DIFF
--- a/app_serving/abort-java-app.yaml
+++ b/app_serving/abort-java-app.yaml
@@ -111,7 +111,7 @@ spec:
 
         # Prepare kubeconfig
         echo "Preparing kubeconfig for target cluster..." | tee -a $ABORT_LOG
-        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
           echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster_id}}" | tee -a $ABORT_LOG
           exit 1

--- a/app_serving/delete-java-app.yaml
+++ b/app_serving/delete-java-app.yaml
@@ -97,7 +97,7 @@ spec:
 
         # Prepare kubeconfig
         echo "Preparing kubeconfig for target cluster..." | tee -a $DELETE_LOG
-        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
           echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster_id}}" | tee -a $DELETE_LOG
           exit 1

--- a/app_serving/promote-java-app.yaml
+++ b/app_serving/promote-java-app.yaml
@@ -110,7 +110,7 @@ spec:
 
         # Prepare kubeconfig
         echo "Preparing kubeconfig for target cluster..." | tee -a $PROMOTE_LOG
-        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
           echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster_id}}" | tee -a $PROMOTE_LOG
           exit 1

--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -432,7 +432,7 @@ spec:
 
         # Prepare kubeconfig
         echo "Preparing kubeconfig for target cluster..." | tee -a $DEPLOY_LOG
-        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        KUBECONFIG_=$(kubectl get secret -n {{workflow.parameters.target_cluster_id}} {{workflow.parameters.target_cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         if [[ -z "$KUBECONFIG_" ]]; then
           echo "Couldn't get kubeconfig for cluster {{workflow.parameters.target_cluster_id}}" | tee -a $DEPLOY_LOG
           exit 1

--- a/cloud-accounts/aws-multi-tenancy-identity.yaml
+++ b/cloud-accounts/aws-multi-tenancy-identity.yaml
@@ -32,10 +32,7 @@ spec:
         metadata:
           name: ${TKS_CLOUD_ACCOUNT_ID}-account-role
         spec:
-          allowedNamespaces:
-            selector:
-              matchLabels:
-                tks-cloud-accout-id: ${TKS_CLOUD_ACCOUNT_ID}
+          allowedNamespaces: {}
           roleARN: \"arn:aws:iam::${AWS_ACCOUNT_ID}:role/controllers.cluster-api-provider-aws.sigs.k8s.io\"
           sourceIdentityRef:
             kind: AWSClusterControllerIdentity

--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -175,7 +175,7 @@ spec:
             echo "[$date] $level     $msg"
           }
 
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 
@@ -221,7 +221,7 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 

--- a/deploy_apps/tks-primary-cluster.yaml
+++ b/deploy_apps/tks-primary-cluster.yaml
@@ -202,7 +202,7 @@ spec:
         #################
         # Check endpoints from the primary_cluster
         #################
-        primary_kube_secret=$(kubectl get secret -n ${primary_cluster} ${primary_cluster}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+        primary_kube_secret=$(kubectl get secret -n ${primary_cluster} ${primary_cluster}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
         # echo -e "primary_kube_secret:\n$primary_kube_secret" | head -n 5
         cat <<< "$primary_kube_secret" > kubeconfig
 

--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -108,7 +108,7 @@ spec:
           kube_params=""
 
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
 

--- a/deploy_apps/tks-remove-servicemesh-wftpl.yaml
+++ b/deploy_apps/tks-remove-servicemesh-wftpl.yaml
@@ -71,7 +71,7 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
             kube_params+="--kubeconfig=/etc/kubeconfig"

--- a/deploy_apps/tks-service-mesh-dashboard-wftpl.yaml
+++ b/deploy_apps/tks-service-mesh-dashboard-wftpl.yaml
@@ -828,7 +828,7 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -937,7 +937,7 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -1020,7 +1020,7 @@ spec:
 
           kube_params=""
           if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /tmp/kubeconfig
             kube_params+="--kubeconfig=/tmp/kubeconfig"
@@ -1150,7 +1150,7 @@ spec:
         - |
           mkdir ~/.kube
           cp /kube/value ~/.kube/config_adm
-          KUBECONFIG_USERCLUSTER=$(kubectl --kubeconfig ~/.kube/config_adm get secret -n ${CLUSTER_ID} ${CLUSTER_ID}-kubeconfig -o=jsonpath='{.data.value}' | base64 -d)
+          KUBECONFIG_USERCLUSTER=$(kubectl --kubeconfig ~/.kube/config_adm get secret -n ${CLUSTER_ID} ${CLUSTER_ID}-tks-kubeconfig -o=jsonpath='{.data.value}' | base64 -d)
           echo -e "kubeconfig_workload:\n$KUBECONFIG_USERCLUSTER" | head -n 5
           cat <<< "$KUBECONFIG_USERCLUSTER" > ~/.kube/config_user
 

--- a/dockerfiles/Dockerfile.tks-cluster-init
+++ b/dockerfiles/Dockerfile.tks-cluster-init
@@ -1,0 +1,16 @@
+# - kubebectl
+# - aws-iam-authenticator
+# - argocd
+# - aws
+# - jq
+# build command: docker build -t harbor-cicd.taco-cat.xyz/tks/tks-cluster-init:v1.0.0 -f Dockerfile.tks-cluster-init .
+
+FROM alpine
+
+RUN apk update
+RUN apk add aws-cli curl bash gettext jq
+RUN curl -Lo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN curl -Lo /usr/local/bin/aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64
+RUN curl -sSL -o /usr/local/bin/argocd https://github.com/argoproj/argo-cd/releases/latest/download/argocd-linux-amd64
+
+RUN chmod +x /usr/local/bin/kubectl /usr/local/bin/aws-iam-authenticator /usr/local/bin/argocd

--- a/git-repo/create-cluster-repo.yaml
+++ b/git-repo/create-cluster-repo.yaml
@@ -13,6 +13,8 @@ spec:
       value: "cluster_uuid"
     - name: template_name
       value: "aws-reference"
+    - name: cloud_account_id
+      value: "NULL"
 
   templates:
   - name: createClusterRepo
@@ -33,7 +35,6 @@ spec:
 
             gh repo create ${USERNAME}/${CLUSTER_ID} --public --confirm
             gh repo create ${USERNAME}/${CLUSTER_ID}-manifests --public --confirm
-
         }
 
         function gitea_create_repo() {
@@ -69,7 +70,6 @@ spec:
 
         cp -r ${CONTRACT_ID}/${TEMPLATE_NAME} ${CLUSTER_ID}/${CLUSTER_ID}
 
-
         ## Replace site-values with fetched params ##
         sed -i "s/clusterName:\ cluster.local/clusterName:\ $CLUSTER_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
         case $INFRA_PROVIDER in
@@ -91,6 +91,13 @@ spec:
             sed -i "s/mdMaxSizePerAz:\ CHANGEME/mdMaxSizePerAz: $val_max_size/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             sed -i "s/mdMachineType:\ CHANGEME/mdMachineType: $val_machine_type/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
             sed -i "s/cpReplicas:\ CHANGEME/cpReplicas: 3/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+
+            ## multi-tenancy ##
+            if [ "$CLOUD_ACCOUNT_ID" = "NULL" ]; then
+              sed -i '/multitenancyId/,+2d' $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            else
+              sed -i "s/cloudAccountID:\ CHANGEME/cloudAccountID: $CLOUD_ACCOUNT_ID/g" $CLUSTER_ID/$CLUSTER_ID/tks-cluster/site-values.yaml
+            fi
             ;;
 
           byoh)
@@ -142,6 +149,8 @@ spec:
         value: "{{workflow.parameters.cluster_id}}"
       - name: TEMPLATE_NAME
         value: "{{workflow.parameters.template_name}}"
+      - name: CLOUD_ACCOUNT_ID
+        value: "{{workflow.parameters.cloud_account_id}}"
       - name: CLUSTER_INFO
         value: "{{inputs.parameters.cluster_info}}"
       volumeMounts:

--- a/sealed_secrets/setup-sealed-secrets-on-usercluster.yaml
+++ b/sealed_secrets/setup-sealed-secrets-on-usercluster.yaml
@@ -32,7 +32,7 @@ spec:
           - name: namespace
             value: kube-system
           - name: kubeconfig_secret_name
-            value: "{{workflow.parameters.site_name}}-kubeconfig"
+            value: "{{workflow.parameters.site_name}}-tks-kubeconfig"
 
     - - name: installControllers
         templateRef:
@@ -68,4 +68,4 @@ spec:
           - name: namespace
             value: default
           - name: kubeconfig_secret_name
-            value: "{{workflow.parameters.site_name}}-kubeconfig"
+            value: "{{workflow.parameters.site_name}}-tks-kubeconfig"

--- a/tests/validate-service-wftpl.yaml
+++ b/tests/validate-service-wftpl.yaml
@@ -35,7 +35,7 @@ spec:
         - /bin/bash
         - -c
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 
@@ -82,7 +82,7 @@ spec:
         - /bin/bash
         - -c
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 

--- a/tests/validate-usercluster-wftpl.yaml
+++ b/tests/validate-usercluster-wftpl.yaml
@@ -36,7 +36,7 @@ spec:
         - /bin/bash
         - '-exc'
         - |
-          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_=$(kubectl get secret -n {{inputs.parameters.cluster_id}} {{inputs.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_" > /etc/kubeconfig_temp
           export KUBECONFIG='/etc/kubeconfig_temp'
 

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -13,7 +13,7 @@ spec:
       value: "C011b88fa"
     - name: site_name
       value: "{{ workflow.parameters.cluster_id }}"
-    - name: cloud_account_id
+    - name: cloud_account_id # will be not NULL if the cluster is multitenancy
       value: "NULL"
     - name: template_name
       value: "aws-reference"
@@ -32,6 +32,9 @@ spec:
   - name: kubeconfig-adm
     secret:
       secretName: tks-admin-kubeconfig-secret
+  - name: awsconfig
+    secret:
+      secretName: awsconfig-secret
   - name: artifacts
     configMap:
       name: aws-artifacts
@@ -113,6 +116,8 @@ spec:
               value: "{{ workflow.parameters.cluster_id }}"
             - name: infra_provider
               value: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}}"
+            - name: cloud_account_id
+              value: "{{ workflow.parameters.cloud_account_id }}"
 
     - - name: create-aws-ebs-csi-iam
         templateRef:
@@ -274,15 +279,18 @@ spec:
       parameters:
         - name: cluster_id
         - name: infra_provider
+        - name: cloud_account_id
     container:
       name: cluster-init
-      image: harbor-cicd.taco-cat.xyz/tks/python_kubectl_argo:v1.1.0
+      image: harbor-cicd.taco-cat.xyz/tks/tks-cluster-init:v1.0.0
       command:
         - /bin/bash
         - '-exc'
         - |
           cp /kube/value kubeconfig_adm
           export KUBECONFIG=kubeconfig_adm
+          mkdir ~/.aws
+          cp /aws/* ~/.aws/
 
           case $INFRA_PROVIDER in
             aws)
@@ -290,14 +298,30 @@ spec:
               kcp_count=$(kubectl get kcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
               awsmcp_count=$(kubectl get awsmcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
 
-              if [ $kcp_count = 1 ]; then
+              if [ $kcp_count = 1 ]; then # Self-managed control plane cluster
                 kubectl wait --for=condition=Available --timeout=3600s kcp -n $CLUSTER_ID $CLUSTER_ID
 
                 KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
-              elif [ $awsmcp_count = 1 ]; then
+              elif [ $awsmcp_count = 1 ]; then # EKS cluster
                 kubectl wait --for=condition=ready --timeout=3600s awsmcp -n $CLUSTER_ID $CLUSTER_ID
-
                 KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-user-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+                if [ "$CLOUD_ACCOUNT_ID" != "NULL" ]; then # multitenancy cluster
+                  IDENTITY_ROLE_ARN=$(kubectl get awsri $CLOUD_ACCOUNT_ID-account-role -ojsonpath='{.spec.roleARN}')
+                  cat <<< $KUBECONFIG_WORKLOAD | sed '/args/,+7d' > tmp_kubeconfig_workload
+                  echo "      args:
+                        - --region
+                        - ap-northeast-2
+                        - eks
+                        - get-token
+                        - --cluster-name
+                        - ${CLUSTER_ID}
+                        - --output
+                        - json
+                        - --role
+                        - ${IDENTITY_ROLE_ARN}
+                        command: aws" | envsubst >> tmp_kubeconfig_workload
+                  KUBECONFIG_WORKLOAD=$(cat tmp_kubeconfig_workload)
+                fi
               else
                 echo "Wrong AWS Cluster type!"
                 exit 1
@@ -365,9 +389,32 @@ spec:
               echo "Warning: $1 is already registered on argo-cd server. If unintended, it may occure woring operations."
           fi
 
+          # Create a kubeconfig secret for TKS internal use from ArgoCD cluster secret.
+          export KUBECONFIG=kubeconfig_adm
+          if [ $kcp_count = 1 ]; then
+            TKS_KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          elif [ $awsmcp_count = 1 ]; then
+            TKS_KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-user-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+            if [ "$CLOUD_ACCOUNT_ID" != "NULL" ]; then
+              cat <<< $TKS_KUBECONFIG_WORKLOAD | sed '/args/,+13d' > tmp_tks_kubeconfig_workload
+              API_SERVER=$(grep server tmp_tks_kubeconfig_workload | awk '{print tolower($2)}')
+              ARGOCD_CLUSTER_SECRET=$(kubectl get secret -n argo | grep ${API_SERVER#*\/\/} | awk '{print $1}')
+              CLIENT_TOKEN=$(kubectl get secret -n argo $ARGOCD_CLUSTER_SECRET -ojsonpath='{.data.config}' | base64 -d | jq -r .bearerToken)
+              echo "    token: ${CLIENT_TOKEN}" >> tmp_tks_kubeconfig_workload
+              TKS_KUBECONFIG_WORKLOAD=$(cat tmp_tks_kubeconfig_workload)
+            fi
+          else
+            echo "Wrong AWS Cluster type!"
+            exit 1
+          fi
+          cat <<< $TKS_KUBECONFIG_WORKLOAD > tks_kubeconfig_workload
+          kubectl create secret generic -n $CLUSTER_ID $CLUSTER_ID-tks-kubeconfig --from-file=value=tks_kubeconfig_workload
+
       volumeMounts:
       - name: kubeconfig-adm
         mountPath: "/kube"
+      - name: awsconfig
+        mountPath: "/aws"
       envFrom:
       - secretRef:
           name: "decapod-argocd-config"
@@ -376,6 +423,8 @@ spec:
         value: "{{ inputs.parameters.cluster_id }}"
       - name: INFRA_PROVIDER
         value: "{{ inputs.parameters.infra_provider }}"
+      - name: CLOUD_ACCOUNT_ID
+        value: "{{ inputs.parameters.cloud_account_id }}"
       - name: TKS_NODE_NAME
         value: "taco"
 

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -13,6 +13,8 @@ spec:
       value: "C011b88fa"
     - name: site_name
       value: "{{ workflow.parameters.cluster_id }}"
+    - name: cloud_account_id
+      value: "NULL"
     - name: template_name
       value: "aws-reference"
     - name: git_account

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -447,7 +447,7 @@ spec:
           kubectl --kubeconfig kubeconfig config delete-context "$ADMIN_USER@$CLUSTER"
           kubectl --kubeconfig kubeconfig config delete-user "$ADMIN_USER"
 
-          KUBECONFIG_WORKLOAD=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_WORKLOAD=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig_workload:\n$KUBECONFIG_WORKLOAD" | head -n 5
           cat <<< "$KUBECONFIG_WORKLOAD" > kubeconfig_workload
 
@@ -464,7 +464,7 @@ spec:
         - /bin/bash
         - '-exc'
         - |
-          KUBECONFIG=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kubeconfig:\n$KUBECONFIG" | head -n 5
           cat <<< "$KUBECONFIG" > kubeconfig_temp
 

--- a/tks-cluster/import-usercluster-wftpl.yaml
+++ b/tks-cluster/import-usercluster-wftpl.yaml
@@ -199,7 +199,7 @@ spec:
           EOF
           kubectl apply -f $CLUSTER_ID_namespace.yaml
 
-          kubectl create secret generic $CLUSTER_ID-kubeconfig -n $CLUSTER_ID --from-file=value=kubeconfig_$CLUSTER_ID
+          kubectl create secret generic $CLUSTER_ID-tks-kubeconfig -n $CLUSTER_ID --from-file=value=kubeconfig_$CLUSTER_ID
 
       volumeMounts:
       - name: kubeconfig-adm
@@ -224,7 +224,7 @@ spec:
           cp /kube/value kubeconfig_adm
           export KUBECONFIG=kubeconfig_adm
 
-          KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$KUBECONFIG_WORKLOAD" > kubeconfig_workload
 
           kubectl --kubeconfig=kubeconfig_workload label node --all taco-lma=enabled taco-ingress-gateway=enabled taco-egress-gateway=enabled servicemesh=enabled --overwrite

--- a/tks-cluster/manage-internal-communication.yaml
+++ b/tks-cluster/manage-internal-communication.yaml
@@ -123,7 +123,7 @@ spec:
         mkdir ~/.kube
         cp /kube/value ~/.kube/config
 
-        kubectl get secret -n $cluster_id ${cluster_id}-kubeconfig -o=jsonpath='{.data.value}' | base64 -d > ~/.kube/config
+        kubectl get secret -n $cluster_id ${cluster_id}-tks-kubeconfig -o=jsonpath='{.data.value}' | base64 -d > ~/.kube/config
 
         # FIX binding address of kubeproxy's metric server to 0.0.0.0
         kubectl get cm -n kube-system kube-proxy -o yaml > /tmp/kube-proxy.cm.yaml

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -258,7 +258,7 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 
@@ -285,7 +285,7 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           echo -e "kube_secret:\n$kube_secret" | head -n 5
           cat <<< "$kube_secret" > /etc/kubeconfig
 


### PR DESCRIPTION
아래 PR이 먼저 머지되어야 합니다.
* https://github.com/openinfradev/tks-flow/pull/162

Self-managed 컨트롤 플레인, EKS, 멀티 테넌시 등 각각의 상황에 따라 달라지는 kubeconfig 대신 TKS 내부에서 사용할 전용 kubeconfig 시크릿(CLUSTER_ID-tks-kubeconfig)을 생성하고 사용하도록 하였습니다.
