### PR TITLE
cloud-accouts: add a policy for multi-tenancy

### DIFF
--- a/cloud-accounts/aws-delete-account.yaml
+++ b/cloud-accounts/aws-delete-account.yaml
@@ -31,7 +31,7 @@ spec:
   templates:
   - name: delete_account_resources
     steps:
-    - - name: provision-iam-resources
+    - - name: delete-iam-resources
         templateRef:
           name: tks-aws-multi-tenancy-iam-resources
           template: bootstrapIam

--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -62,10 +62,16 @@ spec:
             trustStatements:
             - Action:
               - \"sts:AssumeRole\"
-              Effect: "Allow"
+              Effect: \"Allow\"
               Principal:
                 AWS:
-                - \"arn:aws:iam::${TKS_AWS_ACCOUNT_ID}:user/${TKS_AWS_USER}\"" | envsubst > bootstrap-manager-account.yaml
+                - \"arn:aws:iam::${TKS_AWS_ACCOUNT_ID}:user/${TKS_AWS_USER}\"
+            extraStatements:
+            - Action:
+              - \"ec2:DescribeInstanceAttribute\"
+              Effect: \"Allow\"
+              Resource:
+              - \"*\"" | envsubst > bootstrap-manager-account.yaml
 
           cat bootstrap-manager-account.yaml
           clusterawsadm bootstrap iam "{{ inputs.parameters.command }}"-cloudformation-stack --config bootstrap-manager-account.yaml


### PR DESCRIPTION
클러스터 노드 간 통신을 위해 보안 그룹을 추가할 때 아래와 같이 기존 보안 그룹 정보를 얻어 오는 부분이 존재합니다.
https://github.com/openinfradev/tks-flow/blob/4077fce3e182135ac0266dbfb5948cdc5cb1f7c8/tks-cluster/manage-internal-communication.yaml#L64 

멀티 테넌시 환경에서는 CAPA에서 생성하는 cluster-api 컨트롤러 Role을 사용하며 기본 정책에서 빠져있는 ```ec2:DescribeInstanceAttribute``` 권한을 추가하였습니다.