### PR TITLE
cloud-accounts: use a secret for tks AWS account and user

### DIFF
--- a/cloud-accounts/aws-create-account.yaml
+++ b/cloud-accounts/aws-create-account.yaml
@@ -9,10 +9,6 @@ spec:
     parameters:
     - name: aws_region
       value: "ap-northeast-2"
-    - name: tks_aws_account_id
-      value: "NULL"
-    - name: tks_aws_user
-      value: "NULL"
     - name: tks_cloud_account_id
       value: "NULL"
     - name: aws_account_id

--- a/cloud-accounts/aws-delete-account.yaml
+++ b/cloud-accounts/aws-delete-account.yaml
@@ -9,11 +9,7 @@ spec:
     parameters:
     - name: aws_region
       value: "ap-northeast-2"
-    - name: tks_aws_account_id
-      value: "NULL"
-    - name: tks_cloud_accout_id
-      value: "NULL"
-    - name: tks_aws_user
+    - name: tks_cloud_account_id
       value: "NULL"
     - name: aws_account_id
       value: "NULL"

--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -9,10 +9,6 @@ spec:
     parameters:
     - name: aws_region
       value: "ap-northeast-2"
-    - name: tks_aws_account_id
-      value: "NULL"
-    - name: tks_aws_user
-      value: "NULL"
     - name: aws_account_id
       value: "NULL"
     - name: aws_access_key_id
@@ -82,6 +78,12 @@ spec:
       - name: AWS_REGION
         value: "{{workflow.parameters.aws_region}}"
       - name: TKS_AWS_ACCOUNT_ID
-        value: "{{workflow.parameters.tks_aws_account_id}}"
+        valueFrom:
+          secretKeyRef:
+            name: tks-aws-user
+            key: account_id
       - name: TKS_AWS_USER
-        value: "{{workflow.parameters.tks_aws_user}}"
+        valueFrom:
+          secretKeyRef:
+            name: tks-aws-user
+            key: user


### PR DESCRIPTION
클라우드 계정 생성/삭제 시 TKS 계정 정보들은 파라미터 대신 K8S 시크릿을 통해 사용하도록 변경하였습니다.