### PR TITLE
EKS 지원을 위한 수정

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -74,10 +74,21 @@ spec:
             value: '{{workflow.parameters.cluster_id}}'
         when: "{{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}} != '' && {{workflow.parameters.cluster_id}} != {{steps.get-clusters-in-contract.outputs.parameters.primary_cluster}}"
 
+    - - name: determine-if-a-mananged-cluster
+        template: determineIfaManagedCluster
+        arguments:
+          parameters:
+          - name: cluster_id
+            value: "{{workflow.parameters.cluster_id}}"
+
     - - name: installApps
         templateRef:
           name: lma-federation
           template: deploy
+        arguments:
+          parameters:
+          - name: is_mananged_cluster
+            value: "{{steps.determine-if-a-mananged-cluster.outputs.parameters.managed_cluster}}"
 
     - - name: update-eps-for-thanos
         templateRef:
@@ -128,6 +139,53 @@ spec:
     activeDeadlineSeconds: 900
     retryStrategy:
       limit: 2
+
+  - name: determineIfaManagedCluster
+    inputs:
+      parameters:
+        - name: cluster_id
+    container:
+      name: cluster-init
+      image: harbor-cicd.taco-cat.xyz/tks/tks-cluster-init:v1.0.0
+      command:
+        - /bin/bash
+        - '-exc'
+        - |
+          cp /kube/value kubeconfig_adm
+          export KUBECONFIG=kubeconfig_adm
+
+          # check whether this workload cluster is managed or not
+          kcp_count=$(kubectl get kcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
+          awsmcp_count=$(kubectl get awsmcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
+
+          if [ $kcp_count = 1 ]; then
+            echo false | tee /mnt/out/managed_cluster.txt
+          elif [ $awsmcp_count = 1 ]; then
+            echo true | tee /mnt/out/managed_cluster.txt
+          else
+            echo "Wrong Cluster type!"
+            exit 1
+          fi
+      volumeMounts:
+      - name: kubeconfig-adm
+        mountPath: "/kube"
+      - name: out
+        mountPath: /mnt/out
+      env:
+      - name: CLUSTER_ID
+        value: "{{ inputs.parameters.cluster_id }}"
+    volumes:
+      - name: out
+        emptyDir: { }
+      - name: kubeconfig-adm
+        secret:
+          secretName: tks-admin-kubeconfig-secret
+    outputs:
+      parameters:
+      - name: managed_cluster
+        valueFrom:
+          default: "Something wrong"
+          path: /mnt/out/managed_cluster.txt
 
   - name: GetMyThanosScEndpoint
     inputs:

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -119,14 +119,6 @@ spec:
             - name: cloud_account_id
               value: "{{ workflow.parameters.cloud_account_id }}"
 
-    - - name: create-aws-ebs-csi-iam
-        templateRef:
-          name: aws-ebs-csi-iam
-          template: createIAMRole
-        when: >-
-            {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws &&
-              {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == true
-
     - - name: install-cluster-autoscaler-rbac
         templateRef:
           name: create-application
@@ -251,7 +243,9 @@ spec:
         templateRef:
           name: manage-internal-communication
           template: deploy
-        when: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws"
+        when: >-
+            {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws &&
+              {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == false
 
     - - name: install-addons-byoh
         templateRef:

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -397,6 +397,20 @@ spec:
               echo "    token: ${CLIENT_TOKEN}" >> tmp_tks_kubeconfig_workload
               TKS_KUBECONFIG_WORKLOAD=$(cat tmp_tks_kubeconfig_workload)
             fi
+
+            cat <<EOF > sc-taco-storage.yaml
+            apiVersion: storage.k8s.io/v1
+            kind: StorageClass
+            metadata:
+              name: taco-storage
+            parameters:
+              fsType: ext4
+              type: gp2
+            provisioner: kubernetes.io/aws-ebs
+            reclaimPolicy: Delete
+            volumeBindingMode: WaitForFirstConsumer
+            EOF
+            kubectl apply -f sc-taco-storage.yaml
           else
             echo "Wrong AWS Cluster type!"
             exit 1

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -303,17 +303,17 @@ spec:
                   IDENTITY_ROLE_ARN=$(kubectl get awsri $CLOUD_ACCOUNT_ID-account-role -ojsonpath='{.spec.roleARN}')
                   cat <<< $KUBECONFIG_WORKLOAD | sed '/args/,+7d' > tmp_kubeconfig_workload
                   echo "      args:
-                        - --region
-                        - ap-northeast-2
-                        - eks
-                        - get-token
-                        - --cluster-name
-                        - ${CLUSTER_ID}
-                        - --output
-                        - json
-                        - --role
-                        - ${IDENTITY_ROLE_ARN}
-                        command: aws" | envsubst >> tmp_kubeconfig_workload
+                - --region
+                - ap-northeast-2
+                - eks
+                - get-token
+                - --cluster-name
+                - ${CLUSTER_ID}
+                - --output
+                - json
+                - --role
+                - ${IDENTITY_ROLE_ARN}
+                command: aws" | envsubst >> tmp_kubeconfig_workload
                   KUBECONFIG_WORKLOAD=$(cat tmp_kubeconfig_workload)
                 fi
               else
@@ -390,7 +390,7 @@ spec:
           elif [ $awsmcp_count = 1 ]; then
             TKS_KUBECONFIG_WORKLOAD=$(kubectl get secret -n $CLUSTER_ID $CLUSTER_ID-user-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             if [ "$CLOUD_ACCOUNT_ID" != "NULL" ]; then
-              cat <<< $TKS_KUBECONFIG_WORKLOAD | sed '/args/,+13d' > tmp_tks_kubeconfig_workload
+              cat <<< $TKS_KUBECONFIG_WORKLOAD | sed '/exec:/,+15d' > tmp_tks_kubeconfig_workload
               API_SERVER=$(grep server tmp_tks_kubeconfig_workload | awk '{print tolower($2)}')
               ARGOCD_CLUSTER_SECRET=$(kubectl get secret -n argo | grep ${API_SERVER#*\/\/} | awk '{print $1}')
               CLIENT_TOKEN=$(kubectl get secret -n argo $ARGOCD_CLUSTER_SECRET -ojsonpath='{.data.config}' | base64 -d | jq -r .bearerToken)

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -95,15 +95,9 @@ spec:
         templateRef:
           name: manage-internal-communication
           template: DeleteInternalCon
-        when: "{{steps.findInfraProvider.outputs.parameters.infra_provider}} == aws"
-
-    - - name: delete-aws-ebs-csi-iam
-        templateRef:
-          name: aws-ebs-csi-iam
-          template: deleteIAMRole
         when: >-
             ( {{steps.findInfraProvider.outputs.parameters.infra_provider}} == aws &&
-              {{steps.findInfraProvider.outputs.parameters.managed_cluster}} == true
+              {{steps.findInfraProvider.outputs.parameters.managed_cluster}} == false
             )
 
     - - name: deleteCsiDriverApp
@@ -157,6 +151,7 @@ spec:
           parameters:
             - name: app_name
               value: "{{workflow.parameters.app_prefix}}-tigera-operator"
+        when: "{{steps.findInfraProvider.outputs.parameters.managed_cluster}} == false"
 
     - - name: deleteClusterCR
         template: deleteClusterCR


### PR DESCRIPTION
- EKS 클러스터 내부 접근을 위한 kubeconfig 생성 부분의 오류 수정
- EKS에서 불필요한 작업 수행하지 않도록 변경
  - EBS CSI 정책은 별도 생성 대신 AWS 내장 정책 사용: https://github.com/openinfradev/decapod-site/pull/129
  - kube-proxy 등 메트릭 접근을 위해 보안 그룹은 별도 설정 불필요 (클러스터 노드 간 통신을 위한 전용 보안 그룹 존재)
- LMA: 대상 클러스터가 EKS 인지 확인하는 작업 추가
- EKS 에서는 PV 를 위한 EBS CSI가 애드온을 통해 자동 설치되지만 기본 스토리지 클래스는 gp2 이름으로 생성. TKS 에서 사용하는 스토리지 클래스 이름인 'taco-storage' 로 스토리지 클래스 배포 과정 추가