### PR TITLE
fix gitea webhook for decapod rendering

### DIFF
--- a/git-repo/event-gitea-render-manifests.yaml
+++ b/git-repo/event-gitea-render-manifests.yaml
@@ -15,6 +15,7 @@ spec:
     inputs:
       parameters:
       - name: decapod_site_repo
+        value: "{{workflow.parameters.decapod_site_repo}}"
     steps:
     - - name: prepare-rendering
         template: prepare-rendering-template

--- a/git-repo/gitea-webhook-event-consumer.yaml
+++ b/git-repo/gitea-webhook-event-consumer.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: argo
 spec:
   event:
-    selector: payload.full_name != "" && metadata["x-github-event"] == ["push"] && discriminator == "gitea-webhook"
+    selector: payload.repository.full_name != "" && metadata["x-github-event"] == ["push"] && discriminator == "gitea-webhook"
   submit:
     workflowTemplateRef:
       name: event-gitea-render-manifests
@@ -13,5 +13,5 @@ spec:
       parameters:
       - name: decapod_site_repo
         valueFrom:
-          event: payload.full_name
+          event: payload.repository.full_name
 


### PR DESCRIPTION
클러스터 사이트 저장소 main 브랜치에 반영했을 때 자동으로 렌더링 및 manifests 저장소 반영되도록 gitea webhook -> argo workflow event consumer 연결 작업(https://github.com/openinfradev/tks-flow/pull/141)에 오류를 수정하였습니다.

Gitea 1.19 버전에서 Authorization Header 지원이 가능하기 때문에 클러스터 사이트 저장소 생성 할 때 관련 Webhook 설정을 추가하면 github 저장소 쓸 때와 동일하게 구성이 가능합니다. (추가 작업 필요)