### PR TITLE
serve-java-app: change update order

### DIFF
--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -246,23 +246,6 @@ spec:
     - - name: deploy-app
         when: "{{workflow.parameters.type}} != 'build'"
         template: deploy-app
-    - - name: notify-deploy-success
-        when: "{{workflow.parameters.type}} != 'build'"
-        templateRef:
-          name: update-tks-asa-status
-          template: updateTksAsaStatus
-        arguments:
-          parameters:
-          - name: organization_id
-            value: "{{workflow.parameters.organization_id}}"
-          - name: asa_id
-            value: "{{workflow.parameters.asa_id}}"
-          - name: asa_task_id
-            value: "{{workflow.parameters.asa_task_id}}"
-          - name: status
-            value: "{{steps.deploy-app.outputs.parameters.status}}"
-          - name: output
-            value: "{{steps.deploy-app.outputs.parameters.deploy_output}}"
     - - name: update-endpoint-url
         when: "{{workflow.parameters.type}} != 'build'"
         templateRef:
@@ -282,6 +265,23 @@ spec:
             value: "{{steps.deploy-app.outputs.parameters.preview_endpoint}}"
           - name: helm_revision
             value: "{{steps.deploy-app.outputs.parameters.revision}}"
+    - - name: notify-deploy-success
+        when: "{{workflow.parameters.type}} != 'build'"
+        templateRef:
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
+        arguments:
+          parameters:
+          - name: organization_id
+            value: "{{workflow.parameters.organization_id}}"
+          - name: asa_id
+            value: "{{workflow.parameters.asa_id}}"
+          - name: asa_task_id
+            value: "{{workflow.parameters.asa_task_id}}"
+          - name: status
+            value: "{{steps.deploy-app.outputs.parameters.status}}"
+          - name: output
+            value: "{{steps.deploy-app.outputs.parameters.deploy_output}}"
 
   #######################
   # Template Definition #


### PR DESCRIPTION
workflow 상에서 status 업데이트 단계와 endpoint/helm_revision 업데이트 단계의 순서를 서로 맞바꾸도록 수정합니다.

현재 구현 상, B/G 배포의 경우 deploy 단계 완료 후 상태값이 먼저 "BLUEGREEN_WAIT" 로 바뀌어버리면 UI 에서 화면 갱신을 멈춰버리므로, 그 이후에 DB에 업데이트되는 helm_revision 등이 화면에 제대로 갱신되지 않기 때문에 상태값 업데이트를 나중에 하도록 순서를 바꾸는 것입니다.
(이건 quick fix이고 향후 전반적으로 UI와 잘 연계될 수 있도록 상태 관리 체계를 refactoring할 예정입니다.)

어차피 두 단계가 서로 의존성이 없이 독립적이므로 순서를 바꾸는 건 작업 수행상에 특별한 영향도가 없는 걸로 파악됩니다.

