### PR TITLE
tks-cluster: fix clusterautoscaler for eks

### DIFF
--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -65,6 +65,16 @@ spec:
             extraStatements:
             - Action:
               - \"ec2:DescribeInstanceAttribute\"
+              - \"iam:ListOpenIDConnectProviders\"
+              - \"iam:GetOpenIDConnectProvider\"
+              - \"iam:CreateOpenIDConnectProvider\"
+              - \"iam:TagOpenIDConnectProvider\"
+              - \"iam:CreatePolicy\"
+              - \"iam:AttachRolePolicy\"
+              - \"iam:DetachRolePolicy\"
+              - \"iam:CreateRole\"
+              - \"iam:DeleteRole\"
+              - \"cloudformation:*\"
               Effect: \"Allow\"
               Resource:
               - \"*\"" | envsubst > bootstrap-manager-account.yaml

--- a/dockerfiles/Dockerfile.tks_aws
+++ b/dockerfiles/Dockerfile.tks_aws
@@ -1,11 +1,14 @@
 FROM weaveworks/eksctl AS eksctl
 #FROM amazon/aws-cli AS awscli
 
-#make a docker image with this CLI: docker build -t harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.0 -f Dockerfile.tks_aws .
+#make a docker image with this CLI: docker build -t harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.3 -f Dockerfile.tks_aws .
 FROM alpine
 COPY --from=eksctl /usr/local/bin/eksctl /usr/bin/eksctl
 RUN apk update
-RUN apk add aws-cli curl bash gettext
+RUN apk add aws-cli curl bash gettext jq
 RUN curl -L https://github.com/kubernetes-sigs/cluster-api-provider-aws/releases/download/v2.0.2/clusterawsadm-linux-amd64 -o clusterawsadm
 RUN chmod +x clusterawsadm
 RUN mv clusterawsadm /usr/local/bin
+# Install kubectl
+RUN curl -Lo /usr/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN chmod +x /usr/bin/kubectl

--- a/tks-cluster/aws-cluster-autoscaler-iam.yaml
+++ b/tks-cluster/aws-cluster-autoscaler-iam.yaml
@@ -9,23 +9,45 @@ spec:
     parameters:
     - name: cluster_id
       value: "Cc81dd656"
+    - name: cloud_account_id # will be not NULL if the cluster is multitenancy
+      value: "NULL"
 
   volumes:
-    - name: awsconfig
-      secret:
-        secretName: awsconfig-secret
+  - name: awsconfig
+    secret:
+      secretName: awsconfig-secret
+  - name: kubeconfig-adm
+    secret:
+      secretName: tks-admin-kubeconfig-secret
 
   templates:
   - name: createIAMRole
     activeDeadlineSeconds: 1800
+    inputs:
+      parameters:
+      - name: cloud_account_id
     container:
-      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.0
+      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.3
       command:
       - /bin/bash
       - -exc
       - |
+        cp /kube/value kubeconfig_adm
+        export KUBECONFIG=kubeconfig_adm
         mkdir ~/.aws
         cp /aws/* ~/.aws/
+
+        # Use AWS STS temporary security credential if multi-tenancy
+        if [ "$CLOUD_ACCOUNT_ID" != "NULL" ]; then
+          ROLE_ARN=$(kubectl get awsri $CLOUD_ACCOUNT_ID-account-role -ojsonpath='{.spec.roleARN}')
+          aws sts assume-role --role-arn $ROLE_ARN --role-session-name "TKS-ClusterAutoscaler-$CLUSTER_ID" --output json | tee ~/assume-role-sts-credential.txt
+          export AWS_ACCESS_KEY_ID=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.AccessKeyId')
+          export AWS_SECRET_ACCESS_KEY=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.SecretAccessKey')
+          export AWS_SESSION_TOKEN=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.SessionToken')
+
+          ROLE_ARN_REMOVED_SUFFIX=${ROLE_ARN%:*}
+          ACCOUNT_ID=${ROLE_ARN_REMOVED_SUFFIX#*::}
+        fi
 
         echo "{
             \"Version\": \"2012-10-17\",
@@ -68,7 +90,7 @@ spec:
         eksctl create iamserviceaccount \
           --name cluster-autoscaler \
           --namespace kube-system \
-          --cluster $CLUSTER_ID
+          --cluster $CLUSTER_ID \
           --role-name "cluster-autoscaler-$CLUSTER_ID" \
           --attach-policy-arn arn:aws:iam::$ACCOUNT_ID:policy/cluster-autoscaler-$CLUSTER_ID \
           --override-existing-serviceaccounts \
@@ -77,25 +99,48 @@ spec:
       env:
       - name: CLUSTER_ID
         value: "{{workflow.parameters.cluster_id}}"
+      - name: CLOUD_ACCOUNT_ID
+        value: "{{workflow.parameters.cloud_account_id}}"
       volumeMounts:
+      - name: kubeconfig-adm
+        mountPath: "/kube"
       - name: awsconfig
         mountPath: "/aws"
 
   - name: deleteIAMRole
     activeDeadlineSeconds: 1800
+    inputs:
+      parameters:
+      - name: cloud_account_id
     container:
-      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.0
+      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.3
       command:
       - /bin/bash
       - -exc
       - |
+        cp /kube/value kubeconfig_adm
+        export KUBECONFIG=kubeconfig_adm
         mkdir ~/.aws
         cp /aws/* ~/.aws/
+
+        # Use AWS STS temporary security credential if multi-tenancy
+        if [ "$CLOUD_ACCOUNT_ID" != "NULL" ]; then
+          ROLE_ARN=$(kubectl get awsri $CLOUD_ACCOUNT_ID-account-role -ojsonpath='{.spec.roleARN}')
+          aws sts assume-role --role-arn $ROLE_ARN --role-session-name "TKS-ClusterAutoscaler-$CLUSTER_ID" --output json | tee ~/assume-role-sts-credential.txt
+          export AWS_ACCESS_KEY_ID=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.AccessKeyId')
+          export AWS_SECRET_ACCESS_KEY=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.SecretAccessKey')
+          export AWS_SESSION_TOKEN=$(cat ~/assume-role-sts-credential.txt | jq -r '.Credentials.SessionToken')
+        fi
+
         eksctl delete iamserviceaccount --cluster $CLUSTER_ID --name cluster-autoscaler --namespace kube-system
 
       env:
       - name: CLUSTER_ID
         value: "{{workflow.parameters.cluster_id}}"
+      - name: CLOUD_ACCOUNT_ID
+        value: "{{workflow.parameters.cloud_account_id}}"
       volumeMounts:
+      - name: kubeconfig-adm
+        mountPath: "/kube"
       - name: awsconfig
         mountPath: "/aws"

--- a/tks-cluster/aws-ebs-csi-iam.yaml
+++ b/tks-cluster/aws-ebs-csi-iam.yaml
@@ -19,7 +19,7 @@ spec:
   - name: createIAMRole
     activeDeadlineSeconds: 1800
     container:
-      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.0
+      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.1
       command:
       - /bin/bash
       - -exc
@@ -50,7 +50,7 @@ spec:
   - name: deleteIAMRole
     activeDeadlineSeconds: 1800
     container:
-      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.0
+      image: harbor-cicd.taco-cat.xyz/tks/tks-aws:v1.0.1
       command:
       - /bin/bash
       - -exc

--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -123,6 +123,10 @@ spec:
         templateRef:
           name: aws-cluster-autoscaler-iam
           template: createIAMRole
+        arguments:
+          parameters:
+            - name: cloud_account_id
+              value: "{{ workflow.parameters.cloud_account_id }}"
         when: >-
             {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws &&
               {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == true
@@ -211,7 +215,7 @@ spec:
             {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} != byoh &&
               {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == false
 
-    - - name: install-cluster-autoscaler
+    - - name: install-cluster-autoscaler-aws
         templateRef:
           name: create-application
           template: installApps
@@ -222,10 +226,11 @@ spec:
               [
                 {
                   "app_group": "tks-cluster",
-                  "path": "k8s-cluster-autoscaler",
+                  "path": "cluster-autoscaler",
                   "namespace": "kube-system",
                   "target_cluster": ""
                 }
+              ]
         when: >-
             {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} != byoh &&
               {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == true

--- a/tks-cluster/remove-usercluster-wftpl.yaml
+++ b/tks-cluster/remove-usercluster-wftpl.yaml
@@ -13,6 +13,8 @@ spec:
       value: "tks-info.tks.svc"
     - name: cluster_id
       value: "Cabbead61"
+    - name: cloud_account_id # will be not NULL if the cluster is multitenancy
+      value: "NULL"
     - name: infra_provider
       value: "aws"
     - name: app_prefix
@@ -92,6 +94,10 @@ spec:
         templateRef:
           name: aws-cluster-autoscaler-iam
           template: deleteIAMRole
+        arguments:
+          parameters:
+            - name: cloud_account_id
+              value: "{{ workflow.parameters.cloud_account_id }}"
         when: >-
             {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} == aws &&
               {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == true


### PR DESCRIPTION
EKS 에서 클러스터 오토스케일링 지원을 위해 업스트림 차트를 사용해서 cluster-autoscaler를 aws 클라우드 프로바이더 구성으로 배포하도록 한 기존 변경 내역에서 오류를 수정하였습니다.
- EKS IRSA 지원: 클라우드 계정 생성 시 사용자 계정에 생성되는 (TKS에서 위임받아 사용할) controllers.cluster-api-provider-aws.sigs.k8s.io IAM Role에 필요한 Policy 추가
- 기타 오류 수정