### PR TITLE
cloud-accounts: fix to unset aws session token env var

### DIFF
--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -35,7 +35,7 @@ spec:
 
         echo $AWS_SESSION_TOKEN
         if [ "$AWS_SESSION_TOKEN" = "NULL" ]; then
-            unset $AWS_SESSION_TOKEN
+            unset AWS_SESSION_TOKEN
         fi
         echo $AWS_SESSION_TOKEN || true
 


### PR DESCRIPTION
MFA를 사용하지 않는 경우 aws session token 환경 변수가 NULL로 설정됩니다. 워크플로우에서 이를 감지하고 해당 환경 변수 자체를 삭제해야 하는데 불필요한 $ 문자열로 인해 정상 동작하지 않았던 오류를 수정합니다.