### PR TITLE
app-serving: make it fail if endpoint is not ready

### DIFF
--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -649,7 +649,14 @@ spec:
         kubectl get svc ${app_name}-preview -n {{workflow.parameters.namespace}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /mnt/out/preview_endpoint
 
         # Writing endpoint to file
-        kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.namespace}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' > /mnt/out/endpoint
+        ep=$(kubectl get svc {{workflow.parameters.app_name}} -n {{workflow.parameters.namespace}} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+
+        if [ -z "$ep" ]; then
+          echo "Couldn't get endpoint url. Exiting.." | tee -a $DEPLOY_LOG
+          exit 1
+        else
+          echo $ep > /mnt/out/endpoint
+        fi
 
         if [[ "$strategy" == "rolling-update" ]]; then
           # Prevent output param from being null

--- a/tks_info/update-asa-endpoint-wftpl.yaml
+++ b/tks_info/update-asa-endpoint-wftpl.yaml
@@ -72,6 +72,7 @@ spec:
                             headers={"Authorization": "Bearer " + TOKEN},
                             json=data)
         if res.status_code != 200:
+          print('text: {}\n'.format(res.text))
           sys.exit('Failed to update endpoint')
 
         res_json = res.json()

--- a/tks_info/update-asa-status-wftpl.yaml
+++ b/tks_info/update-asa-status-wftpl.yaml
@@ -69,6 +69,7 @@ spec:
                             headers={"Authorization": "Bearer " + TOKEN},
                             json=data)
         if res.status_code != 200:
+          print('text: {}\n'.format(res.text))
           sys.exit('Failed to update status')
 
         res_json = res.json()


### PR DESCRIPTION
AWS 상에 이슈가 있어 LB endpoint가 제대로 할당되지 않을시, workflow를 fail 처리하도록 함.