### PR TITLE
app-serving: deploy 이후 단계도 로그 기록하도록 수정

### DIFF
--- a/app_serving/serve-java-app.yaml
+++ b/app_serving/serve-java-app.yaml
@@ -131,7 +131,25 @@ spec:
             value: "DEPLOY_FAILED"
           - name: output
             value: "{{workflow.outputs.parameters.deploy_output_global}}"
-        when: "{{workflow.status}} != Succeeded && ('{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'deploy-app' || '{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'update-endpoint-url')"
+        when: "{{workflow.status}} != Succeeded && '{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'deploy-app'"
+    - - name: notify-update-failure
+        templateRef:
+          name: update-tks-asa-status
+          template: updateTksAsaStatus
+        arguments:
+          parameters:
+          - name: organization_id
+            value: "{{workflow.parameters.organization_id}}"
+          - name: asa_id
+            value: "{{workflow.parameters.asa_id}}"
+          - name: asa_task_id
+            value: "{{workflow.parameters.asa_task_id}}"
+          # TODO: this can be changed to "UPDATE_FAILED" once the API's pipeline structure is updated.
+          - name: status
+            value: "DEPLOY_FAILED"
+          - name: output
+            value: "{{workflow.outputs.parameters.update_output_global}}"
+        when: "{{workflow.status}} != Succeeded && '{{steps.parse-failed-step.outputs.parameters.step_name}}' == 'update-endpoint-url'"
 
   - name: main
     steps:

--- a/tks_info/update-asa-endpoint-wftpl.yaml
+++ b/tks_info/update-asa-endpoint-wftpl.yaml
@@ -12,6 +12,15 @@ spec:
       value: "http://tks-api.tks.svc:9110"
   templates:
   - name: updateTksAsaEndpoint
+    volumes:
+    - name: out
+      emptyDir: {}
+    outputs:
+      parameters:
+      - name: update_output
+        valueFrom:
+          path: /mnt/out/update_output.log
+        globalName: update_output_global
     inputs:
       parameters:
       - name: organization_id
@@ -22,6 +31,9 @@ spec:
       - name: helm_revision
     script:
       image: harbor-cicd.taco-cat.xyz/tks/centos-tks-api:v1.0
+      volumeMounts:
+      - name: out
+        mountPath: /mnt/out
       command: ["python"]
       env:
       - name: PYTHONPATH
@@ -44,6 +56,10 @@ spec:
         ENDPOINT_URL = '{{inputs.parameters.endpoint}}'
         PREVIEW_ENDPOINT_URL = '{{inputs.parameters.preview_endpoint}}'
         HELM_REVISION = '{{inputs.parameters.helm_revision}}'
+        UPDATE_LOG='/mnt/out/update_output.log'
+        logStr = ""
+        errStr = "Failed to update endpoint!"
+        loginErrStr = "Failed to login to TKS API!"
 
 
         def getToken():
@@ -55,7 +71,12 @@ spec:
 
           res = requests.post(TKS_API_URL + '/api/1.0/auth/login', json=data)
           if res.status_code != 200:
-            sys.exit('Failed to login')
+            logStr='response text: {}\n'.format(res.text))
+            with open(UPDATE_LOG, "a") as f:
+              f.write(logStr)
+              f.write(loginErrStr)
+            print(logStr)
+            sys.exit(loginErrStr)
           res_json = res.json()
           return res_json['user']['token']
 
@@ -72,8 +93,14 @@ spec:
                             headers={"Authorization": "Bearer " + TOKEN},
                             json=data)
         if res.status_code != 200:
-          print('text: {}\n'.format(res.text))
-          sys.exit('Failed to update endpoint')
+          logStr='response text: {}\n'.format(res.text))
+          with open(UPDATE_LOG, "a") as f:
+            f.write(logStr)
+            f.write(errStr)
+          print(logStr)
+          sys.exit(errStr)
 
         res_json = res.json()
         print(res_json)
+        with open(UPDATE_LOG, "a") as f:
+          f.write(res_json)

--- a/tks_info/update-asa-endpoint-wftpl.yaml
+++ b/tks_info/update-asa-endpoint-wftpl.yaml
@@ -71,7 +71,7 @@ spec:
 
           res = requests.post(TKS_API_URL + '/api/1.0/auth/login', json=data)
           if res.status_code != 200:
-            logStr='response text: {}\n'.format(res.text))
+            logStr='response text: {}\n'.format(res.text)
             with open(UPDATE_LOG, "a") as f:
               f.write(logStr)
               f.write(loginErrStr)
@@ -93,7 +93,7 @@ spec:
                             headers={"Authorization": "Bearer " + TOKEN},
                             json=data)
         if res.status_code != 200:
-          logStr='response text: {}\n'.format(res.text))
+          logStr='response text: {}\n'.format(res.text)
           with open(UPDATE_LOG, "a") as f:
             f.write(logStr)
             f.write(errStr)


### PR DESCRIPTION
앱서빙 workflow 수행시 deploy 단계 이후 update-endpoint 단계에서도 로그를 쌓도록 하여, 실제 실패시에 사용자가 마지막 단계의 로그를 볼 수 있도록 함. 
https://github.com/openinfradev/tks-issues/issues/697
