### PR TITLE
tks-cli: increase timeout threshold for cluster creation

### DIFF
--- a/tks-cli/tks-cli.yaml
+++ b/tks-cli/tks-cli.yaml
@@ -117,7 +117,7 @@ spec:
             --tks-node-cnt $TKS_NODE_CNT \
             --user-node-cnt $USER_NODE_CNT
 
-          threshold=30
+          threshold=60
           for i in $(seq 1 $threshold)
           do
             CL_STATUS=$(tks cluster list "{{inputs.parameters.organization_id}}" | grep $CL_NAME | awk '{ print $4 }')


### PR DESCRIPTION
stack을 통해 클러스터 생성할 때 기다리는 시간을 30분에서 60분으로 증가합니다.