### PR TITLE
cloud-accouts: fix IAM roles per cluster

### DIFF
--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -43,7 +43,7 @@ spec:
         kind: AWSIAMConfiguration
         spec:
           eks:
-            iamRoleCreation: false
+            iamRoleCreation: true
             managedMachinePool:
               disable: false
               extraPolicyAttachments:
@@ -70,6 +70,7 @@ spec:
               - \"iam:CreateOpenIDConnectProvider\"
               - \"iam:TagOpenIDConnectProvider\"
               - \"iam:CreatePolicy\"
+              - \"iam:GetPolicy\"
               - \"iam:AttachRolePolicy\"
               - \"iam:DetachRolePolicy\"
               - \"iam:CreateRole\"


### PR DESCRIPTION
EKS 클러스터 별 IAM Role 생성하도록 Admin 클러스터 계정 환경은 변경하였으나 외부 계정 쪽 설정이 누락된 부분이 있어서 수정하였습니다.