### PR TITLE
feature. use  branch from secret when decapod rendering.

### DIFF
--- a/git-repo/create-git-repo-svc-token-secret.yaml
+++ b/git-repo/create-git-repo-svc-token-secret.yaml
@@ -15,6 +15,8 @@ spec:
       value: "gitea"
     - name: git_svc_url
       value: "http://gitea-http.gitea.svc:3000"
+    - name: git_base_branch
+      value: "main"
   templates:
   - name: createTokenSecret
     activeDeadlineSeconds: 120
@@ -32,4 +34,5 @@ spec:
           --from-literal=TOKEN="{{workflow.parameters.token}}" \
           --from-literal=GIT_SVC_TYPE="{{workflow.parameters.git_svc_type}}" \
           --from-literal=GIT_SVC_URL="{{workflow.parameters.git_svc_url}}" \
+          --from-literal=GIT_BASE_BRANCH="{{workflow.parameters.git_base_branch}}" \
           -n argo

--- a/git-repo/event-gitea-render-manifests.yaml
+++ b/git-repo/event-gitea-render-manifests.yaml
@@ -10,7 +10,7 @@ spec:
     - name: decapod_site_repo
       value: "org/cluster_id"
     - name: base_repo_branch
-      value: "main"
+      value: ""
 
   templates:
   - name: main
@@ -103,8 +103,12 @@ spec:
             https_enabled="false"
         fi
 
-        DECAPOD_SITE_REPO={{inputs.parameters.decapod_site_repo}}
         BASE_REPO_BRANCH={{inputs.parameters.base_repo_branch}}
+        if [ "$BASE_REPO_BRANCH" = "" ];then
+            BASE_REPO_BRANCH=${GIT_BASE_BRANCH%:*}
+        fi
+
+        DECAPOD_SITE_REPO={{inputs.parameters.decapod_site_repo}}
 
         gitea_org=${DECAPOD_SITE_REPO%\/*}
 


### PR DESCRIPTION
렌더링시 webhook 호출의 경우는 branch를 지정해줄수 없습니다.
따라서, 렌더링시 workflow parameter 에 명시적으로 branch 를 지정해주지 않을 경우에는 secret 정보의 값을 사용하여 렌더링 하도록 변경합니다.

@intelliguy 님.
이대로 하면 어떨지 의견 부탁 드립니다.