### PR TITLE
keycloak secret 이름 변경에 따른 수정

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -545,11 +545,8 @@ spec:
 
 
           # Login to keycloak
-          admin_username=$(kubectl get secret -n keycloak credential-tks-keycloak -o jsonpath="{.data.ADMIN_USERNAME}" | base64 -d)
-          admin_password=$(kubectl get secret -n keycloak credential-tks-keycloak -o jsonpath="{.data.ADMIN_PASSWORD}" | base64 -d)
-          TOKEN=$(curl -s -k -X POST ${keycloak_url}/auth/realms/master/protocol/openid-connect/token -d grant_type=password -d username=${admin_username} -d password=${admin_password} -d client_id=admin-cli | jq -r '.access_token')
-
-          
+          admin_password=$(kubectl get secret -n keycloak keycloak -o jsonpath="{.data.admin-password}" | base64 -d)
+          TOKEN=$(curl -s -k -X POST ${keycloak_url}/auth/realms/master/protocol/openid-connect/token -d grant_type=password -d username=admin -d password=${admin_password} -d client_id=admin-cli | jq -r '.access_token')          
 
           client_uuid=$(curl -s -k GET -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" ${keycloak_url}/auth/admin/realms/${organization_id}/clients\?\clientId\=grafana | jq -r ' .[] | {id} | .id')
           if [ -z "$client_uuid" ]; then

--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -343,9 +343,8 @@ spec:
           fi
           
           # Login to keycloak
-          admin_username=$(kubectl get secret -n keycloak credential-tks-keycloak -o jsonpath="{.data.ADMIN_USERNAME}" | base64 -d)
-          admin_password=$(kubectl get secret -n keycloak credential-tks-keycloak -o jsonpath="{.data.ADMIN_PASSWORD}" | base64 -d)
-          TOKEN=$(curl -k -X POST ${keycloak_url}/auth/realms/master/protocol/openid-connect/token -d grant_type=password -d username=${admin_username} -d password=${admin_password} -d client_id=admin-cli | jq -r '.access_token')
+          admin_password=$(kubectl get secret -n keycloak keycloak -o jsonpath="{.data.admin-password}" | base64 -d)
+          TOKEN=$(curl -s -k -X POST ${keycloak_url}/auth/realms/master/protocol/openid-connect/token -d grant_type=password -d username=admin -d password=${admin_password} -d client_id=admin-cli | jq -r '.access_token')
 
           # Get client uuid
           client_uuid=$(curl -s -k GET -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" ${keycloak_url}/auth/admin/realms/${organization_id}/clients\?\clientId\=grafana | jq -r ' .[] | {id} | .id')


### PR DESCRIPTION
keycloak의 secret 중 admin 계정/비밀번호를 저장하는 리소스가 있으며, 이 리소스를 활용하는 logic이 존재.

keycloak helm chart 최신화에 따라 secret name이  "credential-tks-keycloak" 에서 "keycloak" 으로 변경되었으며, 이에 따라 필요한 내용 수정함