### PR TITLE
bug fix: Added error handling for grafana endpoint retrieval

### DIFF
--- a/deploy_apps/tks-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-lma-federation-wftpl.yaml
@@ -485,6 +485,7 @@ spec:
           f.write(cur_cluster_name)
 
   - name: create-keycloak-client
+    activeDeadlineSeconds: 600
     inputs:
       parameters:
       - name: organization_id
@@ -523,26 +524,25 @@ spec:
           # Get endpoints
           #################
 
-          endpoint=\"grafa\"
           kube_secret=$(kubectl get secret -n ${cluster_id} ${cluster_id}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$kube_secret" > kubeconfig
-          if [ `kubectl --kubeconfig=kubeconfig get svc -n lma grafana --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-            while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]
-            do
-              if [ "$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.spec.type}")" -neq "LoadBalancer" ]; then
-                log "FAIL" "A service for the grafana in ${cluster_id} is not configured properly.(No LoadBalancer)"
-                exit -1
-              fi
-
-              echo "Waiting for generating the loadbalancer of grafana(3s)"
-              sleep 3
-            done
-
-            endpoint=$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
-          else
-            log "WARN" "Cluster(${cluster_id}) has no grafana"
-          fi
-
+          
+          while ! kubectl --kubeconfig=kubeconfig get svc -n lma grafana --ignore-not-found; do
+            echo "Waiting for the grafana service to appear in cluster ${cluster_id} (5s)"
+            sleep 5
+          done
+          
+          while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]; do
+            if [ "$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath='{.spec.type}')" != "LoadBalancer" ]; then
+              log "FAIL" "A service for the grafana in ${cluster_id} is not configured properly.(No LoadBalancer)"
+              exit -1
+            fi
+        
+            echo "Waiting for generating the loadbalancer of grafana(3s)"
+            sleep 3
+          done
+          
+          endpoint=$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
 
           # Login to keycloak
           admin_password=$(kubectl get secret -n keycloak keycloak -o jsonpath="{.data.admin-password}" | base64 -d)

--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -302,6 +302,7 @@ spec:
             f.write(']')
 
   - name: remove-keycloak-client
+    activeDeadlineSeconds: 300
     inputs:
       parameters:
         - name: organization_id
@@ -325,25 +326,25 @@ spec:
           # Get endpoints
           #################
 
-          endpoint=\"grafa\"
           kube_secret=$(kubectl get secret -n ${cluster_id} ${cluster_id}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
           cat <<< "$kube_secret" > kubeconfig
-          if [ `kubectl --kubeconfig=kubeconfig get svc -n lma grafana --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-            while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]
-            do
-              if [ "$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.spec.type}")" -neq "LoadBalancer" ]; then
-                log "FAIL" "A service for the grafana in ${cluster_id} is not configured properly.(No LoadBalancer)"
-                exit -1
-              fi
-
-              echo "Waiting for generating the loadbalancer of grafana(3s)"
-              sleep 3
-            done
-
-            endpoint=$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
-          else
-            log "WARN" "Cluster(${cluster_id}) has no grafana"
-          fi
+          
+          while ! kubectl --kubeconfig=kubeconfig get svc -n lma grafana --ignore-not-found; do
+            echo "Waiting for the grafana service to appear in cluster ${cluster_id} (5s)"
+            sleep 5
+          done
+          
+          while [ -z $(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[*].hostname}") ]; do
+            if [ "$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath='{.spec.type}')" != "LoadBalancer" ]; then
+              log "FAIL" "A service for the grafana in ${cluster_id} is not configured properly.(No LoadBalancer)"
+              exit -1
+            fi
+          
+            echo "Waiting for generating the loadbalancer of grafana(3s)"
+            sleep 3
+          done
+          
+          endpoint=$(kubectl --kubeconfig=kubeconfig get svc -n lma grafana -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
           
           # Login to keycloak
           admin_password=$(kubectl get secret -n keycloak keycloak -o jsonpath="{.data.admin-password}" | base64 -d)


### PR DESCRIPTION
grafana svc가 생성되지 않았을 때, 비정상 상태임에도 불구하고 정상적으로 진행하던 bug 존재.
수정사항:
grafana svc가 생성되고, loadbalancer type의 external IP가 할당될 때까지 대기 한 후, 남은 로직 진행.
만약, 제한된 시간 내에 값이 추출되지 않을 경우 worflow 실패 처리