### PR TITLE
bug fix: add safety checks to avoid accidental client removal

### DIFF
--- a/deploy_apps/tks-remove-lma-federation-wftpl.yaml
+++ b/deploy_apps/tks-remove-lma-federation-wftpl.yaml
@@ -358,6 +358,7 @@ spec:
             JSON_DATA=$(curl -s -k GET -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" ${keycloak_url}/auth/admin/realms/${organization_id}/clients\?\clientId\=grafana)
             # Convert the array to a JSON array
             num_redirect_uris=$(echo $JSON_DATA | jq '.[0].redirectUris | length')
+            last_redirect_uri=$(echo $JSON_DATA | jq -r '.[0].redirectUris[-1]')
             if [ $num_redirect_uris -gt 1 ]
             then
                 # Remove endpoint from client redirectUris
@@ -365,9 +366,11 @@ spec:
                 # Write the JSON array to a new file
                 echo "$MODIFIED_JSON" > modified_data.json
                 curl -s -k -X PUT -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d @modified_data.json ${keycloak_url}/auth/admin/realms/${organization_id}/clients/${client_uuid} 
-            else
+            elif [ $num_redirect_uris -eq 1 ] && [ "$last_redirect_uri" == "http://$endpoint/*" ]; then
                 # Remove client
                 curl -s -k -X DELETE -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" ${keycloak_url}/auth/admin/realms/${organization_id}/clients/${client_uuid}
+            else
+              echo "no redirect uri to remove"
             fi
           fi
       envFrom:


### PR DESCRIPTION
특정 redirect URI 삭제 과정에서 의도치 않게정상 redirect URI를 포함한 client 자체를 삭제하는 이슈 발생.
이에 대한 방어 로직 추가합니다.