### PR TITLE
check each type of MachinePool for aws

### DIFF
--- a/deploy_apps/tks-primary-cluster.yaml
+++ b/deploy_apps/tks-primary-cluster.yaml
@@ -330,8 +330,8 @@ spec:
         fi
 
         S3_SERVICE="s3://ap-northeast-2"
-        cp /kube/value kubeconfig_adm
-        export KUBECONFIG=kubeconfig_adm
+        cp /kube/value ~/kubeconfig_adm
+        export KUBECONFIG=~/kubeconfig_adm
 
         #################
         # updates
@@ -371,15 +371,17 @@ spec:
           yq -i e ".charts |= map(select(.name == \"loki\").override.loki.storageConfig.aws.dynamodb.dynamodb_url=\"dynamodb://ap-northeast-2\")" ${member}/lma/site-values.yaml
           yq -i e ".charts |= map(select(.name == \"loki\").override.loki.storageConfig.aws.bucketnames=\"${primary_cluster}-tks-loki\")" ${member}/lma/site-values.yaml
 
-          if [ `kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-            if [ -z $iamRoles ]; then
-              iamRoles="\"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+          for machine_type in AWSManagedMachinePool AWSMachinePool; do
+            if [ `kubectl get ${machine_type} -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+              if [ -z $iamRoles ]; then
+                iamRoles="\"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+              else
+                iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+              fi
             else
-              iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+              log "WARN" "Cluster(${member}) has no node role for taco-lma (CR: ${machine_type})"
             fi
-          else
-            log "WARN" "Cluster(${member}) has no node role for taco-lma"
-          fi
+          done
 
           cd -
         done
@@ -620,8 +622,8 @@ spec:
         if [[ "$S3_SERVICE" == "" ]]; then
 
           S3_SERVICE="s3://ap-northeast-2"
-          cp /kube/value kubeconfig_adm
-          export KUBECONFIG=kubeconfig_adm
+          cp /kube/value ~/kubeconfig_adm
+          export KUBECONFIG=~/kubeconfig_adm
 
           #################
           # updates
@@ -752,8 +754,8 @@ spec:
           fi
         done
 
-        cp /kube/value kubeconfig_adm
-        export KUBECONFIG=kubeconfig_adm
+        cp /kube/value ~/kubeconfig_adm
+        export KUBECONFIG=~/kubeconfig_adm
 
         if [[ "$OBJECT_STORE" == "s3" ]]; then
           #################
@@ -767,17 +769,18 @@ spec:
             iamPrefix=${ROLE_ARN%/*}
           fi
           
-          for member in $member_clusters
-          do
-            if [ `kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-              if [ -z $iamRoles ]; then
-                iamRoles="\"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+          for member in $member_clusters; do
+            for machine_type in AWSManagedMachinePool AWSMachinePool; do
+              if [ `kubectl get ${machine_type} -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+                if [ -z $iamRoles ]; then
+                  iamRoles="\"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+                else
+                  iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+                fi
               else
-                iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
+                log "WARN" "Cluster(${member}) has no node role for taco-lma (CR: ${machine_type})"
               fi
-            else
-              log "WARN" "Cluster(${member}) has no node role for taco-lma"
-            fi
+            done
           done
         fi
 

--- a/deploy_apps/tks-primary-cluster.yaml
+++ b/deploy_apps/tks-primary-cluster.yaml
@@ -371,17 +371,21 @@ spec:
           yq -i e ".charts |= map(select(.name == \"loki\").override.loki.storageConfig.aws.dynamodb.dynamodb_url=\"dynamodb://ap-northeast-2\")" ${member}/lma/site-values.yaml
           yq -i e ".charts |= map(select(.name == \"loki\").override.loki.storageConfig.aws.bucketnames=\"${primary_cluster}-tks-loki\")" ${member}/lma/site-values.yaml
 
-          for machine_type in AWSManagedMachinePool AWSMachinePool; do
-            if [ `kubectl get ${machine_type} -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-              if [ -z $iamRoles ]; then
-                iamRoles="\"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
-              else
-                iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
-              fi
+          if [ `kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+            if [ -z $iamRoles ]; then
+              iamRoles="\"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
             else
-              log "WARN" "Cluster(${member}) has no node role for taco-lma (CR: ${machine_type})"
+              iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
             fi
-          done
+          elif [ `kubectl get AWSMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+            if [ -z $iamRoles ]; then
+              iamRoles="\"${iamPrefix}/nodes.cluster-api-provider-aws.sigs.k8s.io\""
+            else
+              iamRoles="${iamRoles}, \"${iamPrefix}/nodes.cluster-api-provider-aws.sigs.k8s.io\""
+            fi
+          else
+            log "WARN" "Cluster(${member}) has no node role for taco-lma"
+          fi
 
           cd -
         done
@@ -770,17 +774,21 @@ spec:
           fi
           
           for member in $member_clusters; do
-            for machine_type in AWSManagedMachinePool AWSMachinePool; do
-              if [ `kubectl get ${machine_type} -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
-                if [ -z $iamRoles ]; then
-                  iamRoles="\"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
-                else
-                  iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get ${machine_type} -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
-                fi
+            if [ `kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+              if [ -z $iamRoles ]; then
+                iamRoles="\"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
               else
-                log "WARN" "Cluster(${member}) has no node role for taco-lma (CR: ${machine_type})"
+                iamRoles="${iamRoles}, \"${iamPrefix}/$(kubectl get AWSManagedMachinePool -n ${member} ${member}-mp-taco  -o jsonpath='{.spec.roleName}')\""
               fi
-            done
+            elif [ `kubectl get AWSMachinePool -n ${member} ${member}-mp-taco --ignore-not-found=true | grep -v NAME | wc -l ` -eq 1 ]; then
+              if [ -z $iamRoles ]; then
+                iamRoles="\"${iamPrefix}/nodes.cluster-api-provider-aws.sigs.k8s.io\""
+              else
+                iamRoles="${iamRoles}, \"${iamPrefix}/nodes.cluster-api-provider-aws.sigs.k8s.io\""
+              fi
+            else
+              log "WARN" "Cluster(${member}) has no node role for taco-lma"
+            fi
           done
         fi
 


### PR DESCRIPTION
clusterapi의 aws와 eks에 대한 머신풀 cr이 다른부분이 있어 이를 모두 확인하도록 하는 기능 추가 (클러스터에 대한 상황체크는 없고 두가지 자원을 모두 체크합니다.)
이에따라 기존 AWSManagedMachinePool 만 체크하던 부분을 AWSManagedMachinePool AWSMachinePool 두가지를 대상으로 하도록 수정합니다,