### PR TITLE
cloud-accounts: add S3 full access iam policy for node role

### DIFF
--- a/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
+++ b/cloud-accounts/aws-multi-tenancy-iam-resources.yaml
@@ -48,11 +48,13 @@ spec:
               disable: false
               extraPolicyAttachments:
               - \"arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy\"
+              - \"arn:aws:iam::aws:policy/AmazonS3FullAccess\"
             fargate:
               disable: true
           nodes:
              extraPolicyAttachments:
              - \"arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy\"
+             - \"arn:aws:iam::aws:policy/AmazonS3FullAccess\"
           clusterAPIControllers:
             disabled: false
             trustStatements:


### PR DESCRIPTION
LMA에서 S3 Bucket 접근을 위한 노드 IAM 권한이 필요하고, self-managed control plane인 경우 (aws*-reference 사이트 사용) 해당 내용이 누락되어 있어 추가합니다.