### PR TITLE
fix kubeconfig generation for cluster-autoscaler

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -173,6 +173,12 @@ spec:
 
         - - name: prepare-cluster-autoscaler
             template: prepare-cluster-autoscaler
+            arguments:
+              parameters:
+                - name: cluster_id
+                  value: "{{ workflow.parameters.cluster_id }}"
+                - name: infra_provider
+                  value: "{{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}}"
             when: >-
               {{steps.tks-create-cluster-repo.outputs.parameters.infra_provider}} != byoh &&
                 {{steps.tks-create-cluster-repo.outputs.parameters.managed_cluster}} == false
@@ -616,6 +622,10 @@ spec:
             value: "{{ inputs.parameters.contract_id }}"
 
     - name: prepare-cluster-autoscaler
+      inputs:
+        parameters:
+          - name: cluster_id
+          - name: infra_provider
       container:
         name: prepare-cluster-autoscaler
         image: harbor.taco-cat.xyz/tks/kubectl-shell:latest-v1.21.1-amd64
@@ -623,16 +633,49 @@ spec:
           - /bin/bash
           - "-exc"
           - |
+            cp /kube/value kubeconfig_adm
+            export KUBECONFIG=kubeconfig
+
             cp /kube/value kubeconfig
 
-            CLUSTER=$(kubectl --kubeconfig kubeconfig get cl -ojsonpath='{.items[0].metadata.name}' -n default)
-            ADMIN_USER=${CLUSTER}-admin
-            TOKEN=$(kubectl --kubeconfig kubeconfig get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl --kubeconfig kubeconfig get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
-            kubectl --kubeconfig kubeconfig config set-credentials cluster-autoscaler --token=$TOKEN
-            kubectl --kubeconfig kubeconfig config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
-            kubectl --kubeconfig kubeconfig config use-context cluster-autoscaler
-            kubectl --kubeconfig kubeconfig config delete-context "$ADMIN_USER@$CLUSTER"
-            kubectl --kubeconfig kubeconfig config delete-user "$ADMIN_USER"
+            CLUSTER=$(kubectl get cl -ojsonpath='{.items[0].metadata.name}' -n default)
+
+            create_cluster_autoscaler_kubeconfig() {
+              ADMIN_CONTEXT=$1
+              ADMIN_USER=$2
+
+              TOKEN=$(kubectl --kubeconfig kubeconfig get secrets -n {{workflow.parameters.cluster_id}} "$(kubectl --kubeconfig kubeconfig get sa cluster-autoscaler -n {{workflow.parameters.cluster_id}} -o=jsonpath={.secrets[0].name})" -o=jsonpath={.data.token} | base64 -d)
+              kubectl --kubeconfig kubeconfig config set-credentials cluster-autoscaler --token=$TOKEN
+              kubectl --kubeconfig kubeconfig config set-context cluster-autoscaler --cluster=$CLUSTER --user=cluster-autoscaler
+              kubectl --kubeconfig kubeconfig config use-context cluster-autoscaler
+
+              kubectl --kubeconfig kubeconfig config delete-context "$ADMIN_CONTEXT"
+              kubectl --kubeconfig kubeconfig config delete-user "$ADMIN_USER"
+
+            }
+
+            case $INFRA_PROVIDER in
+              aws)
+                # check whether admin cluster is managed or not
+                kcp_count=$(kubectl get kcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
+                awsmcp_count=$(kubectl get awsmcp -n $CLUSTER_ID $CLUSTER_ID | grep -v NAME | wc -l)
+
+                if [ $kcp_count = 1 ]; then # Self-managed control plane cluster
+                  create_cluster_autoscaler_kubeconfig "$CLUSTER-admin@$CLUSTER" "$CLUSTER-admin"
+                elif [ $awsmcp_count = 1 ]; then # EKS cluster
+                  CURRENT_CONTEXT=$(kubectl --kubeconfig kubeconfig config current-context)
+                  create_cluster_autoscaler_kubeconfig "$CURRENT_CONTEXT" "$CURRENT_CONTEXT"
+                else
+                  echo "Wrong AWS Cluster type!"
+                  exit 1
+                fi
+                ;;
+
+               *)
+                echo "Error: wrong infra provider"
+                exit 1
+                ;;
+            esac
 
             KUBECONFIG_WORKLOAD=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-tks-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kubeconfig_workload:\n$KUBECONFIG_WORKLOAD" | head -n 5
@@ -642,6 +685,11 @@ spec:
         volumeMounts:
           - name: kubeconfig-adm
             mountPath: "/kube"
+        env:
+          - name: CLUSTER_ID
+            value: "{{ inputs.parameters.cluster_id }}"
+          - name: INFRA_PROVIDER
+            value: "{{ inputs.parameters.infra_provider }}"
 
     - name: install-volumesnapshot-crds
       container:


### PR DESCRIPTION
어드민 클러스터가 EKS인 경우 kubeconfig 형식/내용이 self-managed 컨트롤 플레인 클러스터와 다르기 때문에 분기해서 처리할 수 있도록 수정하였습니다.