### PR TITLE
Preserve namespace on app deletion

### DIFF
--- a/app_serving/delete-java-app.yaml
+++ b/app_serving/delete-java-app.yaml
@@ -134,7 +134,8 @@ spec:
 
         # Delete preview svc and namespace
         kubectl delete service --all -n {{workflow.parameters.namespace}} 2> >(tee -a $DELETE_LOG >&2) || true
-        kubectl delete ns {{workflow.parameters.namespace}} || true
+        ## Do not delete ns for now
+        # kubectl delete ns {{workflow.parameters.namespace}} || true
         
         echo "App {{workflow.parameters.app_name}} was deleted successfully." | tee -a $DELETE_LOG
 


### PR DESCRIPTION
테크 서밋 핸즈온에서 단일 namespace에 복수개의 app을 배포하게 되므로, 앱 삭제시 namespace를 유지하도록 합니다. 
임시 커밋이고, 향후 프로젝트 등 체계 개편 방향에 맞추어 로직을 정할 예정입니다.