### PR TITLE
trivial. change admin cluster name on dev environment

### DIFF
--- a/tks-cluster/create-usercluster-wftpl.yaml
+++ b/tks-cluster/create-usercluster-wftpl.yaml
@@ -643,7 +643,7 @@ spec:
             case $INFRA_PROVIDER in
               aws)
                 # check whether admin cluster is managed or not
-                kcp_count=$(kubectl get kcp -n default $CLUSTER | grep -v NAME | wc -l)
+                kcp_count=$(kubectl get kcp -n default $CLUSTER-control-plane | grep -v NAME | wc -l)
                 awsmcp_count=$(kubectl get awsmcp -n default $CLUSTER | grep -v NAME | wc -l)
 
                 if [ $kcp_count = 1 ]; then # Self-managed control plane cluster


### PR DESCRIPTION
dev 환경은 다름 환경과 admin cluster 의 이름이 다르게 구축되어 있어 develop branch 코드에 적용합니다.