### PR TITLE
trivial. rename base branch name for creating contract

### DIFF
--- a/git-repo/create-contract-repo.yaml
+++ b/git-repo/create-contract-repo.yaml
@@ -54,6 +54,7 @@ spec:
 
         git clone -b ${REVISION} $GIT_SVC_HTTP://$(echo -n $TOKEN)@${GIT_SVC_BASE_URL}/${USERNAME}/decapod-site.git
         cd decapod-site
+        git switch -c newbranch
         echo "Decapod Site Repo Revision: "${REVISION} > META
         echo "Decapod Site Repo Commit: "$(git rev-parse HEAD) >> META
 
@@ -85,7 +86,7 @@ spec:
         git commit -m "new contract: ${CONTRACT_ID}"
 
         git remote add new_contract $GIT_SVC_HTTP://$(echo -n $TOKEN)@${GIT_SVC_BASE_URL}/${USERNAME}/${CONTRACT_ID}
-        git push new_contract ${REVISION}:main
+        git push new_contract newbranch:main
         cd ..
 
       envFrom:


### PR DESCRIPTION
admin cluster 를 tag 기준(branch가 아닌)으로 셋업할 경우 오류가 발생하는 부분을 수정하였습니다.

@zugwan  HEAD detach 상태에서 remote 로 push 가 되지 않는 현상인데, 이 변경이 맞는건지 체크 바랍니다. 테스트는 완료하였습니다.