### PR TITLE
lma-primary: update logic for object store

### DIFF
--- a/deploy_apps/tks-primary-cluster.yaml
+++ b/deploy_apps/tks-primary-cluster.yaml
@@ -518,7 +518,7 @@ spec:
           fi
         fi
 
-        if [[ "$OBJECT_STORE" == "minio" ]]; then
+        if [[ "${primary_cluster}" == "${current_cluster}" ]] && [[ "$OBJECT_STORE" == "minio" ]]; then
           S3_SERVICE=$(kubectl get secret -n ${primary_cluster} tks-endpoint-secret -o jsonpath='{.data.minio}'| base64 -d )
           if [[ "$S3_SERVICE" == "" ]]; then
             S3_HOST=$(kubectl --kubeconfig=kubeconfig get svc -n lma minio -o jsonpath="{.status.loadBalancer.ingress[0].hostname}")
@@ -540,7 +540,7 @@ spec:
         for member in $member_clusters
         do
           # 1. endpoint of fb on eachcluster
-          log "INFO" "##### change the loki target to $LOKI_HOST:$LOKI_PORT and $S3_SERVICE (the current target is ${member})"
+          log "INFO" "##### change the loki target to $LOKI_HOST:$LOKI_PORT (the current target is ${member})"
           [ -d ${member} ] || git clone ${repository_base}${member}
           cd ${member}
 
@@ -548,9 +548,6 @@ spec:
           yq -i e  ".global.lokiPort=\"${LOKI_PORT}\"" ${member}/lma/site-values.yaml
           yq -i e  ".global.lokiuserHost=\"${LOKI_USER_HOST}\"" ${member}/lma/site-values.yaml
           yq -i e  ".global.lokiuserPort=\"${LOKI_USER_PORT}\"" ${member}/lma/site-values.yaml
-          if [[ "$OBJECT_STORE" == "minio" ]]; then
-            yq -i e  ".global.s3Service=\"${S3_SERVICE}\"" ${member}/lma/site-values.yaml
-          fi
 
           yq -i e  ".global.clusterName=\"${member}\"" ${member}/lma/site-values.yaml
 
@@ -559,6 +556,9 @@ spec:
             yq -i e  ".global.grafanaDatasourceMetric=\"thanos-query.lma:9090\"" ${member}/lma/site-values.yaml
             yq -i e  ".global.TksWebhookUrl=\"{{workflow.parameters.alert_tks}}\"" ${member}/lma/site-values.yaml
             yq -i e  ".global.SlackUrl=\"{{workflow.parameters.alert_slack}}\"" ${member}/lma/site-values.yaml
+            if [[ "$OBJECT_STORE" == "minio" ]]; then
+              yq -i e  ".global.s3Service=\"${S3_SERVICE}\"" ${member}/lma/site-values.yaml
+            fi
           else
             yq -i e  ".global.grafanaDatasourceMetric=\"lma-prometheus.lma:9090\"" ${member}/lma/site-values.yaml
           fi
@@ -573,9 +573,9 @@ spec:
         do
           cd ${member}
           if [[ `git status --porcelain` ]]; then
-            log "INFO" "##### commit changes on ${member} to $LOKI_HOST:$LOKI_PORT and $S3_SERVICE"
+            log "INFO" "##### commit changes on ${member} to loki: $LOKI_HOST:$LOKI_PORT "
             if [[ "$OBJECT_STORE" == "minio" ]]; then
-              cmessage="the loki to $LOKI_HOST:$LOKI_PORT and grafana to $S3_SERVICE (cluster ${member})"
+              cmessage="the loki to $LOKI_HOST:$LOKI_PORT and prometheus to $S3_SERVICE (cluster ${member})"
             else
               cmessage="the loki to $LOKI_HOST:$LOKI_PORT (cluster ${member})"
             fi


### PR DESCRIPTION
object store에 대한 수정

1. 근본적으로 이 플로우에서 object store에 대한 조작을 진행함
2. 영향을 받는 부분은 
   - loki의 백엔드로서
   - prometheus의 장기저장소로서
3. loki 부분은 primary에서만 잘 하면됨
4. prometheus 부분은 맴버 클러스터에서도 어디에 연결되어야 할지 알아야 함

현재 구조는
- default는 s3로 하고 있고
- 사용자가 minio로 지정한 경우 이 설정을 수정하도록 하는 부분이 본 workflow

따라서, 명확하게 minio라고 지정하지 않으면 prometheus 연결에서 문제가 발생할수 있음

다만, 현재의 상황 (primary=aws, member=byoh)에서는 현 pr로 해소됨
(primary=byoh, member=aws)라면 문제가 발생할 것임
현재 byoh가 사용된 케이스(BTV)에서는 항상 endpoint-secret가 존재했으므로 본 로직을 통과하지 않기도 함