### PR TITLE
chagne CRD directory to aviod argo-cd app name duplication

### DIFF
--- a/git-repo/render-manifests.yaml
+++ b/git-repo/render-manifests.yaml
@@ -137,12 +137,12 @@ spec:
             /installer/template -b ${BASE_DIR}/${app} -o ${site}/${app}/site-values.yaml --output ${OUTPUT_DIR}/${site}/${app}
             log 0 "INFO" "Successfully Generate ${app} manifests Files!"
 
-            mkdir ${OUTPUT_DIR}/$site/$app/CRD
+            mkdir ${OUTPUT_DIR}/$site/$app/${app}-CRD
 
-            echo "Move every CustomResourceDefinition to ${OUTPUT_DIR}/$site/$app/CRD"
-            for i in `find ${OUTPUT_DIR}/$site/$app | grep CustomResourceDefinition | grep -v '/CRD/'`
+            echo "Move every CustomResourceDefinition to ${OUTPUT_DIR}/$site/$app/${app}-CRD"
+            for i in `find ${OUTPUT_DIR}/$site/$app | grep CustomResourceDefinition | grep -v '/${app}-CRD/'`
             do
-              mv $i ${OUTPUT_DIR}/$site/$app/CRD
+              mv $i ${OUTPUT_DIR}/$site/$app/${app}-CRD
             done
           done
 


### PR DESCRIPTION
argo-cd에서 어플리케이션 이름을 디렉토리를 가져다 쓰고 있고 이름 지정에 중복이 발생하여 명시적으로 앱그룹을 명시합니다.